### PR TITLE
Check for ggplot2 is a different way

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -31,9 +31,9 @@ is_distribution <- function(x) {
 plot_cdf <- function(d, limits = NULL, p = 0.001,
                      plot_theme = ggplot2::theme_minimal){
 
-  if(!"ggplot2" %in% loadedNamespaces())
-    stop("You must load ggplot2 for this function to work.")
-
+  if (!requireNamespace("ggplot2", quietly = TRUE)) {
+    stop("the ggplot2 package is needed. Please install it.", call. = FALSE)
+  }
   if(is.null(limits))
     limits <- support(d)
 
@@ -90,10 +90,9 @@ plot_cdf <- function(d, limits = NULL, p = 0.001,
 plot_pdf <- function(d, limits = NULL, p = 0.001,
                      plot_theme = ggplot2::theme_bw){
 
-  if(!"ggplot2" %in% loadedNamespaces())
-    stop("You must load ggplot2 for this function to work.")
-
-
+  if (!requireNamespace("ggplot2", quietly = TRUE)) {
+    stop("the ggplot2 package is needed. Please install it.", call. = FALSE)
+  }
   if(is.null(limits))
     limits <- support(d)
 


### PR DESCRIPTION
An attempt to avoid the error on travis stemming from the check for ggplot2 in plot_cdf() and plot_pdf().