### PR TITLE
Fix base plot "checking for variable name"

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -179,7 +179,7 @@ plot.distribution <- function(x, cdf = FALSE, p = c(0.1, 99.9), len = 1000,
   # Set x and y axis labels. If the variable name is a single upper case letter
   # then use that name in the labels.  Otherwise, use the generic x and
   # P(X = x) or f(x).
-  variable_name <- substitute(x)
+  variable_name <- deparse(substitute(x))
   if (length(variable_name) == 1 && nchar(variable_name) == 1 && toupper(variable_name) == variable_name) {
     my_xlab <- tolower(substitute(x))
     if (cdf) {

--- a/R/plot.R
+++ b/R/plot.R
@@ -180,7 +180,7 @@ plot.distribution <- function(x, cdf = FALSE, p = c(0.1, 99.9), len = 1000,
   # then use that name in the labels.  Otherwise, use the generic x and
   # P(X = x) or f(x).
   variable_name <- substitute(x)
-  if (nchar(variable_name) == 1 & toupper(variable_name) == variable_name) {
+  if (length(variable_name) == 1 && nchar(variable_name) == 1 && toupper(variable_name) == variable_name) {
     my_xlab <- tolower(substitute(x))
     if (cdf) {
       my_ylab <- paste0("F(", my_xlab, ")")


### PR DESCRIPTION
Alex (@alexpghayes),

this contains a minor PR for fixing the warnings in the base plot generic encountered in PR #74 by @zeileis. The plot function currently [checks if the variable name is a single upper case letter](https://github.com/alexpghayes/distributions3/blob/0c9c86ea2c67221f4597e7b0603e19964f5a9fa3/R/plot.R#L179-L183). 

This only works for existing distribution objects:
```r
R> N <- Normal(1)
R> plot(N)
R> plot(Normal(1))
Warning message:
In if (nchar(variable_name) == 1 & toupper(variable_name) == variable_name) { :
  the condition has length > 1 and only the first element will be used
```

More generally, would you like me to write an issue or even a PR to unify the plot functions? Currently there is a `plot.distributions3()` with the boolean argument `cdf`, as well as the functions `plot_pdf()` and `plot_cdf()` based on ggplot2:

* In a first step, it would be reasonable to unify `plot()` and `autoplot()` with the arguments `type = c("pdf", "cdf"))`.
* In a further step it might be even possible to provide an interface to the package `ggdist`?