### PR TITLE
Preparations for CRAN version 0.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: distributions3
 Title: Probability Distributions as S3 Objects
-Version: 0.2.0.9000
+Version: 0.2.1
 Authors@R: c(
     person("Alex", "Hayes", , "alexpghayes@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-4985-5160")),
@@ -17,8 +17,8 @@ Authors@R: c(
     person("Alessandro", "Gasparini", , "alessandro.gasparini@ki.se", role = "ctb")
   )
 Description: Tools to create and manipulate probability distributions
-    using S3.  Generics random(), pdf(), cdf() and quantile() provide
-    replacements for base R's r/d/p/q style functions.  Functions and
+    using S3.  Generics pdf(), cdf(), quantile(), and random() provide
+    replacements for base R's d/p/q/r style functions.  Functions and
     arguments have been named carefully to minimize confusion for students
     in intro stats courses. The documentation for each distribution
     contains detailed mathematical notes.

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,11 @@
   reported by the `summary()` method. Now the default is to use the maximum-likelihood estimate
   instead (divided by the number of observations, n) which is consistent with the `logLik()`
   method. The previous behavior can be obtained by specifying `sigma = "OLS"` (#91).
+- Similarly to the `lm` method the `glm` method `prodist(..., dispersion = NULL)` now, by
+  default, uses the `dispersion` estimate that matches the `logLik()` output. This is based
+  on the deviance divided by the number of observations, n. Alternatively,
+  `dispersion = "Chisquared"` uses the estimate employed in the `summary()` method,
+  based on the Chi-squared statistic divided by the residual degrees of freedom, n - k.
 - Small improvements in methods for various distribution objects: Added `support()` method
   for GEV-based distributions (`GEV()`, `GP()`, `Gumbel()`, `Frechet()`). Added a
   `random()` method for the `Tukey()` distribution (using the inversion method).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,49 @@
+# distributions3 0.2.1
+
+- New generics `is_discrete()` and `is_continous()` with methods for all distribution objects
+  in the package. The `is_discrete()` methods return `TRUE` for every distribution that is discrete
+  on the entire support and `FALSE` otherwise. Analogously, `is_continuous()` returns `TRUE` for
+  every distribution that is continuous on the entire support and `FALSE` otherwise. Thus, for
+  mixed discrete-continuous distributions both methods should yield `FALSE` (#90).
+- New logical argument `elementwise = NULL` in `apply_dpqr()` and hence inherited in
+  `cdf()`, `pdf()`, `log_pdf()`, and `quantile()`. It provides type-safety when
+  applying one of the functions to a vector of distributions `d` to a numeric
+  argument `x` where both `d` and `x` are of length n > 1. By setting `elementwise = TRUE`
+  the function is applied element-by-element, also yielding a vector of length n.
+  By setting `elementwise = FALSE` the function is applied for all combinations
+  yielding an n-by-n matrix. The default `elementwise = NULL` corresponds to `FALSE`
+  if `d` and `x` are of different lengths and `TRUE` if the are of the same length
+  n > 1 (#87).
+- Extended support for various count data distributions, now enompassing both the Poisson
+  and negative binomial distributions along with various adjustments for zero counts
+  (hurdle, inflation, and truncation, respectively). More details are provided in the
+  following items (#86).
+- New `d`/`p`/`q`/`r` functions for `hnbinom`, `zinbinom`, `ztnbinom`, and `ztpois` similar
+  to the corresponding `nbinom` and `pois` functions from base R.
+- New `HurdleNegativeBinomial()`, `ZINegativeBinomial()`, `ZTNegativeBinomial()`, and
+  `ZTPoisson()` distribution constructors along with the corresponding S3 methods for the
+  "usual" generics (except `skewness()` and `kurtosis()`).
+- New `prodist()` methods for extracting the fitted/predicted probability distributions from
+  models estimated by `hurdle()`, `zeroinfl()`, and `zerotrunc()` objects from either the
+  `pscl` package or the `countreg` package.
+- Added argument `prodist(..., sigma = "ML")` to the `lm` method for extracting the
+  fitted/predicted probability distribution from a linear regression model. In the previous
+  version the `prodist()` method always used the least-squares estimate of the error variance
+  (= residual sum of squares divided by the residual degrees of freedom, n - k), as also
+  reported by the `summary()` method. Now the default is to use the maximum-likelihood estimate
+  instead (divided by the number of observations, n) which is consistent with the `logLik()`
+  method. The previous behavior can be obtained by specifying `sigma = "OLS"` (#91).
+- Small improvements in methods for various distribution objects: Added `support()` method
+  for GEV-based distributions (`GEV()`, `GP()`, `Gumbel()`, `Frechet()`). Added a
+  `random()` method for the `Tukey()` distribution (using the inversion method).
+
+
 # distributions3 0.2.0
 
 - Vectorized univariate distribution objects by Moritz Lang and Achim Zeileis (#71 and #82).
   This allows representation of fitted probability distributions from regression models.
   New helper functions are provided to help setting up such distribution objects in
-  a unified way. In particular, `apply_dpqr()` helps to apply the standard d/p/q/r functions
+  a unified way. In particular, `apply_dpqr()` helps to apply the standard `d`/`p`/`q`/`r` functions
   available in base R and many packages. The accompanying manual page provides some
   worked examples and further guidance.
 - New vignette (by Achim Zeileis) on using `distributions3` to go from basic probability

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -20,6 +20,11 @@
 #' the mean plus further parameters describing scale, dispersion, shape, etc.).
 #' Second, the \code{distributions} objects are set up using the generator
 #' functions from \pkg{distributions3}.
+#'
+#' Note that these probability distributions only reflect the random variation in
+#' the dependent variable based on the model employed (and its associated
+#' distributional assumpation for the dependent variable). This does not capture
+#' the uncertainty in the parameter estimates.
 #' 
 #' For both linear regression models and generalized linear models, estimated
 #' by \code{lm} and \code{glm} respectively, there is some ambiguity as to which
@@ -27,9 +32,9 @@
 #' \code{\link[stats]{logLik}} methods use the maximum-likelihood (ML) estimate
 #' implicitly, the \code{summary} methods report an estimate that is standardized
 #' with the residual degrees of freedom, n - k (rather than the number of
-#' observations, n, only). The \code{prodist} methods for these objects follow
+#' observations, n). The \code{prodist} methods for these objects follow
 #' the \code{logLik} method by default but the \code{summary} behavior can be
-#' mimicked by setting the \code{sigma} and \code{dispersion} arguments
+#' mimicked by setting the \code{sigma} or \code{dispersion} arguments
 #' accordingly.
 #' 
 #' @aliases prodist.lm prodist.glm prodist.negbin prodist.Arima prodist.hurdle prodist.zeroinfl prodist.zerotrunc

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -21,6 +21,17 @@
 #' Second, the \code{distributions} objects are set up using the generator
 #' functions from \pkg{distributions3}.
 #' 
+#' For both linear regression models and generalized linear models, estimated
+#' by \code{lm} and \code{glm} respectively, there is some ambiguity as to which
+#' estimate for the dispersion parameter of the model is to be used. While the
+#' \code{\link[stats]{logLik}} methods use the maximum-likelihood (ML) estimate
+#' implicitly, the \code{summary} methods report an estimate that is standardized
+#' with the residual degrees of freedom, n - k (rather than the number of
+#' observations, n, only). The \code{prodist} methods for these objects follow
+#' the \code{logLik} method by default but the \code{summary} behavior can be
+#' mimicked by setting the \code{sigma} and \code{dispersion} arguments
+#' accordingly.
+#' 
 #' @aliases prodist.lm prodist.glm prodist.negbin prodist.Arima prodist.hurdle prodist.zeroinfl prodist.zerotrunc
 #' 
 #' @param object A model object.
@@ -28,6 +39,19 @@
 #' underlying \code{\link[stats]{predict}} methods, e.g., \code{newdata} for
 #' \code{\link[stats]{lm}} or \code{\link[stats]{glm}} objects or \code{n.ahead}
 #' for \code{\link[stats]{arima}} objects.
+#' @param sigma character or numeric or \code{NULL}. Specification of the standard
+#' deviation \code{sigma} to be used for the \code{\link{Normal}} distribution in the
+#' \code{lm} method. The default \code{"ML"} (or equivalently \code{"MLE"} or \code{NULL})
+#' uses the maximum likelihood estimate based on the residual sum of squares divided
+#' by the number of observations, n. Alternatively, \code{sigma = "OLS"} uses the
+#' least-squares estimate (divided by the residual degrees of freedom, n - k). Finally,
+#' a concrete numeric value can also be specified in \code{sigma}.
+#' @param dispersion character or numeric or \code{NULL}. Specification of the
+#' dispersion parameter in the \code{glm} method. The default \code{NULL}
+#' (or equivalently \code{"deviance"}) is to use the \code{\link[stats]{deviance}}
+#' divided by the number of observations, n. Alternatively, \code{dispersion = "Chisquared"}
+#' uses the Chi-squared statistic divided by the residual degrees of freedom, n - k.
+#' Finally, a concrete numeric value can also be specified in \code{dispersion}.
 #' 
 #' @return An object inheriting from \code{distribution}.
 #' 
@@ -106,25 +130,49 @@ prodist <- function(object, ...) {
   UseMethod("prodist")
 }
 
+#' @rdname prodist
 #' @export
-prodist.lm <- function(object, ...) {
+prodist.lm <- function(object, ..., sigma = "ML") {
+  ## predicted means
   mu <- predict(object, ...)
-  sigma <- sqrt(sum(residuals(object)^2)/df.residual(object))
+
+  ## estimated sigma
+  if(is.null(sigma)) sigma <- "ML"
+  if(is.character(sigma)) {
+    sigma <- match.arg(toupper(sigma), c("mle", "ols"))
+    wts <- if(is.null(object$weights)) 1 else object$weights
+    sigma <- switch(sigma,
+      "MLE" = sqrt(sum(wts * residuals(object)^2)/nobs(object)),
+      "OLS" = sqrt(sum(wts * residuals(object)^2)/df.residual(object)))
+  }
+  if(!is.numeric(sigma)) stop("unknown specification of sigma")
+
+  ## set up distribution
   Normal(mu = mu, sigma = sigma)
 }
 
+#' @rdname prodist
 #' @export
 prodist.glm <- function(object, ..., dispersion = NULL) {
   ## fitted means
   mu <- predict(object, type = "response", ...)
 
   ## dispersion parameter phi
-  phi <- dispersion
+  if(is.null(dispersion)) {
+    phi <- NULL
+  } else if(is.character(dispersion)) {
+    phi <- NULL
+    dispersion <- match.arg(gsub("-", "", tolower(dispersion), fixed = TRUE), c("deviance", "chisquared"))
+  } else {
+    phi <- dispersion
+  }
   if(is.null(phi)) { 
     phi <- if(object$family$family %in% c("poisson", "binomial")) {
       1
     } else {
-      sum((object$weights * object$residuals^2)[object$weights > 0])/ df.residual(object)
+      switch(dispersion,
+        "deviance" = deviance(object)/nobs(object),
+        "chisquared" = sum((object$weights * object$residuals^2)[object$weights > 0])/df.residual(object))
     }
   }
   

--- a/R/prodist.R
+++ b/R/prodist.R
@@ -66,7 +66,6 @@
 #' @keywords distribution
 #' 
 #' @examples
-#' 
 #' ## Model: Linear regression
 #' ## Fit: lm
 #' ## Data: 1920s cars data
@@ -79,6 +78,13 @@
 #' pd <- prodist(reg)
 #' head(pd)
 #' 
+#' ## Extract log-likelihood from model object
+#' logLik(reg)
+#' 
+#' ## Replicate log-likelihood via distributions object
+#' sum(log_pdf(pd, cars$dist))
+#' log_likelihood(pd, cars$dist)
+#'
 #' ## Compute corresponding medians and 90% interval
 #' qd <- quantile(pd, c(0.05, 0.5, 0.95))
 #' head(qd)
@@ -86,6 +92,13 @@
 #' ## Visualize observations with predicted quantiles
 #' plot(dist ~ speed, data = cars)
 #' matplot(cars$speed, qd, add = TRUE, type = "l", col = 2, lty = 1)
+#' 
+#' ## Sigma estimated by maximum-likelihood estimate (default, used in logLik)
+#' ## vs. least-squares estimate (used in summary)
+#' nd <- data.frame(speed = 50)
+#' prodist(reg, newdata = nd, sigma = "ML")
+#' prodist(reg, newdata = nd, sigma = "OLS")
+#' summary(reg)$sigma
 #' 
 #' 
 #' ## Model: Poisson generalized linear model
@@ -144,7 +157,7 @@ prodist.lm <- function(object, ..., sigma = "ML") {
   ## estimated sigma
   if(is.null(sigma)) sigma <- "ML"
   if(is.character(sigma)) {
-    sigma <- match.arg(toupper(sigma), c("mle", "ols"))
+    sigma <- match.arg(toupper(sigma), c("MLE", "OLS"))
     wts <- if(is.null(object$weights)) 1 else object$weights
     sigma <- switch(sigma,
       "MLE" = sqrt(sum(wts * residuals(object)^2)/nobs(object)),
@@ -165,6 +178,7 @@ prodist.glm <- function(object, ..., dispersion = NULL) {
   ## dispersion parameter phi
   if(is.null(dispersion)) {
     phi <- NULL
+    dispersion <- "deviance"
   } else if(is.character(dispersion)) {
     phi <- NULL
     dispersion <- match.arg(gsub("-", "", tolower(dispersion), fixed = TRUE), c("deviance", "chisquared"))

--- a/README.Rmd
+++ b/README.Rmd
@@ -56,7 +56,7 @@ devtools::install_github("alexpghayes/distributions3")
 The basic usage of `distributions3` looks like:
 
 ```{r}
-library(distributions3)
+library("distributions3")
 
 X <- Bernoulli(0.1)
 
@@ -71,7 +71,7 @@ Note that `quantile()` **always** returns lower tail probabilities. If you aren'
 
 ## Contributing
 
-`distributions3` is not under active development, but is fairly stable and used by several academics for teaching intro stat courses. We are happy to review PRs contributing bug fixes. If you are interested in more actively maintaining and developing `distributions3`, please reach out on Github!
+If you are interested in contributing to `distributions3`, please reach out on Github! We are happy to review PRs contributing bug fixes.
 
 Please note that `distributions3` is released with a
 [Contributor Code of Conduct](https://alexpghayes.github.io/distributions3/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ devtools::install_github("alexpghayes/distributions3")
 The basic usage of `distributions3` looks like:
 
 ``` r
-library(distributions3)
+library("distributions3")
 
 X <- Bernoulli(0.1)
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,8 @@ the plot.
 
 ## Contributing
 
-`distributions3` is not under active development, but is fairly stable
-and used by several academics for teaching intro stat courses. We are
-happy to review PRs contributing bug fixes. If you are interested in
-more actively maintaining and developing `distributions3`, please reach
-out on Github!
+If you are interested in contributing to `distributions3`, please reach
+out on Github! We are happy to review PRs contributing bug fixes.
 
 Please note that `distributions3` is released with a [Contributor Code
 of

--- a/man/distributions3-package.Rd
+++ b/man/distributions3-package.Rd
@@ -6,7 +6,7 @@
 \alias{distributions3-package}
 \title{distributions3: Probability Distributions as S3 Objects}
 \description{
-Tools to create and manipulate probability distributions using S3. Generics random(), pdf(), cdf() and quantile() provide replacements for base R's r/d/p/q style functions. Functions and arguments have been named carefully to minimize confusion for students in intro stats courses. The documentation for each distribution contains detailed mathematical notes.
+Tools to create and manipulate probability distributions using S3. Generics pdf(), cdf(), quantile(), and random() provide replacements for base R's d/p/q/r style functions. Functions and arguments have been named carefully to minimize confusion for students in intro stats courses. The documentation for each distribution contains detailed mathematical notes.
 }
 \seealso{
 Useful links:

--- a/man/prodist.Rd
+++ b/man/prodist.Rd
@@ -12,6 +12,10 @@
 \title{Extracting fitted or predicted probability distributions from models}
 \usage{
 prodist(object, ...)
+
+\method{prodist}{lm}(object, ..., sigma = "ML")
+
+\method{prodist}{glm}(object, ..., dispersion = NULL)
 }
 \arguments{
 \item{object}{A model object.}
@@ -20,6 +24,21 @@ prodist(object, ...)
 underlying \code{\link[stats]{predict}} methods, e.g., \code{newdata} for
 \code{\link[stats]{lm}} or \code{\link[stats]{glm}} objects or \code{n.ahead}
 for \code{\link[stats]{arima}} objects.}
+
+\item{sigma}{character or numeric or \code{NULL}. Specification of the standard
+deviation \code{sigma} to be used for the \code{\link{Normal}} distribution in the
+\code{lm} method. The default \code{"ML"} (or equivalently \code{"MLE"} or \code{NULL})
+uses the maximum likelihood estimate based on the residual sum of squares divided
+by the number of observations, n. Alternatively, \code{sigma = "OLS"} uses the
+least-squares estimate (divided by the residual degrees of freedom, n - k). Finally,
+a concrete numeric value can also be specified in \code{sigma}.}
+
+\item{dispersion}{character or numeric or \code{NULL}. Specification of the
+dispersion parameter in the \code{glm} method. The default \code{NULL}
+(or equivalently \code{"deviance"}) is to use the \code{\link[stats]{deviance}}
+divided by the number of observations, n. Alternatively, \code{dispersion = "Chisquared"}
+uses the Chi-squared statistic divided by the residual degrees of freedom, n - k.
+Finally, a concrete numeric value can also be specified in \code{dispersion}.}
 }
 \value{
 An object inheriting from \code{distribution}.
@@ -46,6 +65,17 @@ or predicted (out-of-sample) distribution parameters. Typically, this includes
 the mean plus further parameters describing scale, dispersion, shape, etc.).
 Second, the \code{distributions} objects are set up using the generator
 functions from \pkg{distributions3}.
+
+For both linear regression models and generalized linear models, estimated
+by \code{lm} and \code{glm} respectively, there is some ambiguity as to which
+estimate for the dispersion parameter of the model is to be used. While the
+\code{\link[stats]{logLik}} methods use the maximum-likelihood (ML) estimate
+implicitly, the \code{summary} methods report an estimate that is standardized
+with the residual degrees of freedom, n - k (rather than the number of
+observations, n, only). The \code{prodist} methods for these objects follow
+the \code{logLik} method by default but the \code{summary} behavior can be
+mimicked by setting the \code{sigma} and \code{dispersion} arguments
+accordingly.
 }
 \examples{
 

--- a/man/prodist.Rd
+++ b/man/prodist.Rd
@@ -66,15 +66,20 @@ the mean plus further parameters describing scale, dispersion, shape, etc.).
 Second, the \code{distributions} objects are set up using the generator
 functions from \pkg{distributions3}.
 
+Note that these probability distributions only reflect the random variation in
+the dependent variable based on the model employed (and its associated
+distributional assumpation for the dependent variable). This does not capture
+the uncertainty in the parameter estimates.
+
 For both linear regression models and generalized linear models, estimated
 by \code{lm} and \code{glm} respectively, there is some ambiguity as to which
 estimate for the dispersion parameter of the model is to be used. While the
 \code{\link[stats]{logLik}} methods use the maximum-likelihood (ML) estimate
 implicitly, the \code{summary} methods report an estimate that is standardized
 with the residual degrees of freedom, n - k (rather than the number of
-observations, n, only). The \code{prodist} methods for these objects follow
+observations, n). The \code{prodist} methods for these objects follow
 the \code{logLik} method by default but the \code{summary} behavior can be
-mimicked by setting the \code{sigma} and \code{dispersion} arguments
+mimicked by setting the \code{sigma} or \code{dispersion} arguments
 accordingly.
 }
 \examples{

--- a/man/prodist.Rd
+++ b/man/prodist.Rd
@@ -83,7 +83,6 @@ mimicked by setting the \code{sigma} or \code{dispersion} arguments
 accordingly.
 }
 \examples{
-
 ## Model: Linear regression
 ## Fit: lm
 ## Data: 1920s cars data
@@ -96,6 +95,13 @@ reg <- lm(dist ~ speed, data = cars)
 pd <- prodist(reg)
 head(pd)
 
+## Extract log-likelihood from model object
+logLik(reg)
+
+## Replicate log-likelihood via distributions object
+sum(log_pdf(pd, cars$dist))
+log_likelihood(pd, cars$dist)
+
 ## Compute corresponding medians and 90\% interval
 qd <- quantile(pd, c(0.05, 0.5, 0.95))
 head(qd)
@@ -103,6 +109,13 @@ head(qd)
 ## Visualize observations with predicted quantiles
 plot(dist ~ speed, data = cars)
 matplot(cars$speed, qd, add = TRUE, type = "l", col = 2, lty = 1)
+
+## Sigma estimated by maximum-likelihood estimate (default, used in logLik)
+## vs. least-squares estimate (used in summary)
+nd <- data.frame(speed = 50)
+prodist(reg, newdata = nd, sigma = "ML")
+prodist(reg, newdata = nd, sigma = "OLS")
+summary(reg)$sigma
 
 
 ## Model: Poisson generalized linear model

--- a/tests/testthat/test-prodist.R
+++ b/tests/testthat/test-prodist.R
@@ -8,19 +8,101 @@ nd <- data.frame(x = 0)
 
 test_that("prodist() works for lm", {
   m_lm <- lm(y ~ x, data = d)
-  expect_equal(prodist(m_lm), Normal(mu = fitted(m_lm), sigma = summary(m_lm)$sigma))
-  expect_equal(prodist(m_lm, newdata = nd), Normal(mu = predict(m_lm, newdata = nd), sigma = summary(m_lm)$sigma))
+  expect_equal(
+    sum(log_pdf(prodist(m_lm), d$y)),
+    as.numeric(logLik(m_lm))
+  )
+  expect_equal(
+    prodist(m_lm, sigma = "ML"),
+    Normal(mu = fitted(m_lm), sigma = sqrt(mean(residuals(m_lm)^2)))
+  )
+  expect_equal(
+    prodist(m_lm, sigma = "ML", newdata = nd),
+    Normal(mu = predict(m_lm, newdata = nd), sigma = sqrt(mean(residuals(m_lm)^2)))
+  )
+  expect_equal(
+    prodist(m_lm, sigma = "OLS"),
+    Normal(mu = fitted(m_lm), sigma = summary(m_lm)$sigma)
+  )
+  expect_equal(
+    prodist(m_lm, sigma = "OLS", newdata = nd),
+    Normal(mu = predict(m_lm, newdata = nd), sigma = summary(m_lm)$sigma)
+  )
 })
 
-test_that("prodist() works for glm", {
-  m_glm <- glm(y ~ x, data = d, family = poisson)
-  expect_equal(prodist(m_glm), Poisson(lambda = fitted(m_glm)))
-  expect_equal(prodist(m_glm, newdata = nd), Poisson(lambda = predict(m_glm, newdata = nd, type = "response")))
+test_that("prodist() works for glm/gaussian", {
+  m_gaus <- glm(y ~ x, data = d, family = gaussian)
+  expect_equal(
+    sum(log_pdf(prodist(m_gaus), d$y)),
+    as.numeric(logLik(m_gaus))
+  )
+  expect_equal(
+    prodist(m_gaus, dispersion = "deviance"),
+    Normal(mu = fitted(m_gaus), sigma = sqrt(mean(residuals(m_gaus)^2)))
+  )
+  expect_equal(
+    prodist(m_gaus, dispersion = "deviance", newdata = nd),
+    Normal(mu = predict(m_gaus, newdata = nd), sigma = sqrt(mean(residuals(m_gaus)^2)))
+  )
+  expect_equal(
+    prodist(m_gaus, dispersion = "Chisquared"),
+    Normal(mu = fitted(m_gaus), sigma = sqrt(summary(m_gaus)$dispersion))
+  )
+  expect_equal(
+    prodist(m_gaus, dispersion = "Chisquared", newdata = nd),
+    Normal(mu = predict(m_gaus, newdata = nd), sigma = sqrt(summary(m_gaus)$dispersion))
+  )
+})
+
+test_that("prodist() works for glm/poisson", {
+  m_pois <- glm(y ~ x, data = d, family = poisson)
+  expect_equal(
+    sum(log_pdf(prodist(m_pois), d$y)),
+    as.numeric(logLik(m_pois))
+  )
+  expect_equal(
+    prodist(m_pois),
+    Poisson(lambda = fitted(m_pois))
+  )
+  expect_equal(
+    prodist(m_pois, newdata = nd),
+    Poisson(lambda = predict(m_pois, newdata = nd, type = "response"))
+  )
+})
+
+test_that("prodist() works for glm/binomial", {
+  m_bin <- glm(I(y > 1) ~ x, data = d, family = binomial)
+  expect_equal(
+    sum(log_pdf(prodist(m_bin), as.numeric(d$y > 1))),
+    as.numeric(logLik(m_bin))
+  )
+  expect_equal(
+    prodist(m_bin),
+    Binomial(p = fitted(m_bin), size = 1)
+  )
+  expect_equal(
+    prodist(m_bin, newdata = nd),
+    Binomial(p = predict(m_bin, newdata = nd, type = "response"), size = 1)
+  )
+})
+
+test_that("prodist() works for glm/gamma", {
+  m_gamma <- glm(I(y + 1) ~ x, data = d, family = stats::Gamma)
+  expect_equal(
+    sum(log_pdf(prodist(m_gamma), d$y + 1)),
+    as.numeric(logLik(m_gamma))
+  )
+  expect_equal(
+    prodist(m_gamma, newdata = nd, dispersion = "Chisquared")$shape,
+    1/summary(m_gamma)$dispersion
+  )
 })
 
 test_that("prodist() works for arima", {
   m_ar <- arima(d$y, order = c(1, 0, 0))
   p_ar <- predict(m_ar, n.ahead = 3)
-  expect_equal(prodist(m_ar, n.ahead = 3),
-    Normal(mu = setNames(as.numeric(p_ar$pred), as.character(time(p_ar$pred))), sigma = as.numeric(p_ar$se)))
+  expect_equal(
+    prodist(m_ar, n.ahead = 3),
+    Normal(mu = setNames(as.numeric(p_ar$pred), as.character(time(p_ar$pred))), sigma = as.numeric(p_ar$se))
+  )
 })


### PR DESCRIPTION
It would be great to have a new CRAN release of `distributions3` (presumably version 0.2.1) so that other packages can build on it more easily. I'm working myself on updates for `topmodels`, `crch`, and `countreg` that will require this version and which should also go to CRAN in the no-so-distant future.

So to prepare for this I did the following:

* Bumped the version to 0.2.1 in the `DESCRIPTION` plus some minor improvements.
* Documented all changes since 0.2.0 in the `NEWS.md`.
* Omitted the comment that `distributions3` is not actively developed in the `README.Rmd`/`md` because I think we have been quite active over the last year :nerd_face:
* Improved documentation, examples, and tests for `prodist()`. Enhanced handling of the scale estimates in `prodist.lm` and `prodist.glm` (see https://github.com/alexpghayes/distributions3/issues/89).

Let me know if I can help with anything else.