### PR TITLE
Patch CDF equation HurdleNegativeBinomial

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # distributions3 (development version)
 
 - Fixed errors in notation of cumulative distribution function in the documentation of
-  `HurdlePoisson()` and `HurdleNegativeBinomial()` (by @dkwhu in #94 and #95).
+  `HurdlePoisson()` and `HurdleNegativeBinomial()` (by @dkwhu in #94 and #96).
 
 
 # distributions3 0.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # distributions3 (development version)
 
+- Fixed errors in notation of cumulative distribution function in the documentation of
+  `HurdlePoisson()` and `HurdleNegativeBinomial()` (by @dkwhu in #94 and #95).
+
+
 # distributions3 0.2.1
 
 - New generics `is_discrete()` and `is_continous()` with methods for all distribution objects

--- a/R/HurdleNegativeBinomial.R
+++ b/R/HurdleNegativeBinomial.R
@@ -153,9 +153,9 @@ rhnbinom <- function(n, mu, theta, size, pi) {
 #'   **Cumulative distribution function (c.d.f.)**: \eqn{P(X \le 0) = 1 - \pi} and for \eqn{k > 0}
 #'
 #'   \deqn{
-#'     P(X = k) = 1 - \pi + \pi \cdot \frac{F(k; \mu, \theta)}{1 - F(0; \mu, \theta)}
+#'     P(X \le k) = 1 - \pi + \pi \cdot \frac{F(k; \mu, \theta) - F(0; \mu, \theta)}{1 - F(0; \mu, \theta)}
 #'   }{
-#'     P(X = k) = 1 - \pi + \pi \cdot F(k; \mu, \theta)/(1 - F(0; \mu, \theta))
+#'     P(X \le k) = 1 - \pi + \pi \cdot (F(k; \mu, \theta) - F(0; \mu, \theta))/(1 - F(0; \mu, \theta))
 #'   }
 #'
 #'   **Moment generating function (m.g.f.)**:

--- a/man/HurdleNegativeBinomial.Rd
+++ b/man/HurdleNegativeBinomial.Rd
@@ -64,9 +64,9 @@ distribution.
 \strong{Cumulative distribution function (c.d.f.)}: \eqn{P(X \le 0) = 1 - \pi} and for \eqn{k > 0}
 
 \deqn{
-    P(X = k) = 1 - \pi + \pi \cdot \frac{F(k; \mu, \theta)}{1 - F(0; \mu, \theta)}
+    P(X \le k) = 1 - \pi + \pi \cdot \frac{F(k; \mu, \theta) - F(0; \mu, \theta)}{1 - F(0; \mu, \theta)}
   }{
-    P(X = k) = 1 - \pi + \pi \cdot F(k; \mu, \theta)/(1 - F(0; \mu, \theta))
+    P(X \le k) = 1 - \pi + \pi \cdot (F(k; \mu, \theta) - F(0; \mu, \theta))/(1 - F(0; \mu, \theta))
   }
 
 \strong{Moment generating function (m.g.f.)}:

--- a/man/HurdlePoisson.Rd
+++ b/man/HurdlePoisson.Rd
@@ -52,9 +52,9 @@ distribution.
 \strong{Cumulative distribution function (c.d.f.)}: \eqn{P(X \le 0) = 1 - \pi} and for \eqn{k > 0}
 
 \deqn{
-    P(X = k) = 1 - \pi + \pi \cdot \frac{F(k; \lambda)}{1 - F(0; \lambda)}
+    P(X \le k) = 1 - \pi + \pi \cdot \frac{F(k; \lambda) - F(0; \lambda)}{1 - F(0; \lambda)}
   }{
-    P(X = k) = 1 - \pi + \pi \cdot F(k; \lambda)/(1 - F(0; \lambda))
+    P(X \le k) = 1 - \pi + \pi \cdot (F(k; \lambda) - F(0; \lambda))/(1 - F(0; \lambda))
   }
 
 where \eqn{F(k; \lambda)} is the c.d.f. of the \code{\link{Poisson}} distribution.


### PR DESCRIPTION
Fix in notation of CDF in `HurdleNegativeBinomial` analogous to the patch of @dkwhu in https://github.com/alexpghayes/distributions3/pull/94. Re-ran `devtools::document()` and include fix in `NEWS.md`.