### PR TITLE
Bug fix for zero-truncated count distributions

### DIFF
--- a/R/ZTNegativeBinomial.R
+++ b/R/ZTNegativeBinomial.R
@@ -48,7 +48,8 @@ dztnbinom <- function(x, mu, theta, size, log = FALSE) {
   if(!missing(size)) theta <- size
   rval <- dnbinom(x, mu = mu, size = theta, log = TRUE) - pnbinom(0, mu = mu, size = theta, lower.tail = FALSE, log.p = TRUE)
   rval[x < 1] <- -Inf
-  rval[mu <= 0] <- 0
+  rval[mu <= 0] <- -Inf
+  rval[(mu <= 0) & (x == 1)] <- 0
   if(log) rval else exp(rval)
 }
 

--- a/R/ZTPoisson.R
+++ b/R/ZTPoisson.R
@@ -44,7 +44,8 @@
 dztpois <- function(x, lambda, log = FALSE) {
   rval <- dpois(x, lambda, log = TRUE) - ppois(0, lambda, lower.tail = FALSE, log.p = TRUE)
   rval[x < 1] <- -Inf
-  rval[lambda <= 0] <- 0
+  rval[lambda <= 0] <- -Inf
+  rval[(lambda <= 0) & (x == 1)] <- 0
   if(log) rval else exp(rval)
 }
 


### PR DESCRIPTION
The density functions `dztpoisson()` and `dztnbinom()` did not handle the edge case` of `lambda = 0` or `mu = 0` correctly if `x != 1`. Added another line of code to catch this.