### PR TITLE
Small fixes & improvements

### DIFF
--- a/R/Bernoulli.R
+++ b/R/Bernoulli.R
@@ -140,7 +140,7 @@ random.Bernoulli <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rbinom(n = at, size = 1, prob = x$p)
+  FUN <- function(at, d) rbinom(n = at, size = 1, prob = d$p)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -237,7 +237,7 @@ cdf.Bernoulli <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.Bernoulli <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qbinom(at, size = 1, prob = x$p, ...)
+  FUN <- function(at, d) qbinom(at, size = 1, prob = d$p, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Beta.R
+++ b/R/Beta.R
@@ -96,7 +96,7 @@ random.Beta <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rbeta(n = at, shape1 = x$alpha, shape2 = x$beta)
+  FUN <- function(at, d) rbeta(n = at, shape1 = d$alpha, shape2 = d$beta)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -193,7 +193,7 @@ cdf.Beta <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.Beta <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qbeta(at, shape1 = x$alpha, shape2 = x$beta, ...)
+  FUN <- function(at, d) qbeta(at, shape1 = d$alpha, shape2 = d$beta, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Binomial.R
+++ b/R/Binomial.R
@@ -153,7 +153,7 @@ random.Binomial <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rbinom(n = at, size = x$size, prob = x$p)
+  FUN <- function(at, d) rbinom(n = at, size = d$size, prob = d$p)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -249,7 +249,7 @@ cdf.Binomial <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.Binomial <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qbinom(at, size = x$size, prob = x$p, ...)
+  FUN <- function(at, d) qbinom(at, size = d$size, prob = d$p, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Cauchy.R
+++ b/R/Cauchy.R
@@ -129,7 +129,7 @@ random.Cauchy <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rcauchy(n = at, location = x$location, scale = x$scale)
+  FUN <- function(at, d) rcauchy(n = at, location = d$location, scale = d$scale)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -226,7 +226,7 @@ cdf.Cauchy <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.Cauchy <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qcauchy(at, location = x$location, scale = x$scale, ...)
+  FUN <- function(at, d) qcauchy(at, location = d$location, scale = d$scale, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/ChiSquare.R
+++ b/R/ChiSquare.R
@@ -145,7 +145,7 @@ random.ChiSquare <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rchisq(n = at, df = x$df)
+  FUN <- function(at, d) rchisq(n = at, df = d$df)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -244,7 +244,7 @@ cdf.ChiSquare <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 quantile.ChiSquare <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   # TODO: in the documentation, more information on return and
   # how quantiles are calculated
-  FUN <- function(at, d) qchisq(at, df = x$df, ...)
+  FUN <- function(at, d) qchisq(at, df = d$df, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Exponential.R
+++ b/R/Exponential.R
@@ -121,7 +121,7 @@ random.Exponential <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rexp(n = at, rate = x$rate)
+  FUN <- function(at, d) rexp(n = at, rate = d$rate)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -218,7 +218,7 @@ cdf.Exponential <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.Exponential <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qexp(at, rate = x$rate, ...)
+  FUN <- function(at, d) qexp(at, rate = d$rate, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Exponential.R
+++ b/R/Exponential.R
@@ -24,11 +24,11 @@
 #'   In the following, let \eqn{X} be an Exponential random variable with
 #'   rate parameter `rate` = \eqn{\lambda}.
 #'
-#'   **Support**: {x in [0, \eqn{\infty})}
+#'   **Support**: \eqn{x \in (0, \infty)}
 #'
-#'   **Mean**: 1 / \eqn{\lambda}
+#'   **Mean**: \eqn{\frac{1}{\lambda}}
 #'
-#'   **Variance**: 1 / \eqn{\lambda^2}
+#'   **Variance**: \eqn{\frac{1}{\lambda^2}}
 #'
 #'   **Probability density function (p.d.f)**:
 #'

--- a/R/FisherF.R
+++ b/R/FisherF.R
@@ -222,7 +222,7 @@ cdf.FisherF <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.FisherF <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qf(at, df1 = x$df1, df2 = x$df2, ncp = x$lambda, ...)
+  FUN <- function(at, d) qf(at, df1 = d$df1, df2 = d$df2, ncp = d$lambda, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Gamma.R
+++ b/R/Gamma.R
@@ -134,7 +134,7 @@ random.Gamma <- function(x, n = 1L, drop = TRUE, ...) {
   if (n == 0L) {
     return(numeric(0L))
   }
-  FUN <- function(at, d) rgamma(n = at, shape = x$shape, rate = x$rate)
+  FUN <- function(at, d) rgamma(n = at, shape = d$shape, rate = d$rate)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
 
@@ -231,7 +231,7 @@ cdf.Gamma <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 #'
 quantile.Gamma <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qgamma(at, shape = x$shape, rate = x$rate, ...)
+  FUN <- function(at, d) qgamma(at, shape = d$shape, rate = d$rate, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/NegativeBinomial.R
+++ b/R/NegativeBinomial.R
@@ -289,9 +289,9 @@ cdf.NegativeBinomial <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #'
 quantile.NegativeBinomial <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   FUN <- if("mu" %in% names(unclass(x))) {
-    function(at, d) qnbinom(p = at, mu = x$mu, size = x$size, ...)
+    function(at, d) qnbinom(p = at, mu = d$mu, size = d$size, ...)
   } else {
-    function(at, d) qnbinom(p = at, size = x$size, prob = x$p, ...)
+    function(at, d) qnbinom(p = at, size = d$size, prob = d$p, ...)
   }
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/StudentsT.R
+++ b/R/StudentsT.R
@@ -303,7 +303,7 @@ cdf.StudentsT <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @family StudentsT distribution
 #'
 quantile.StudentsT <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qt(p = at, df = x$df, ...)
+  FUN <- function(at, d) qt(p = at, df = d$df, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Tukey.R
+++ b/R/Tukey.R
@@ -130,7 +130,7 @@ cdf.Tukey <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @family Tukey distribution
 #'
 quantile.Tukey <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qtukey(p = at, nmeans = x$nmeans, df = x$df, nranges = x$nranges, ...)
+  FUN <- function(at, d) qtukey(p = at, nmeans = d$nmeans, df = d$df, nranges = d$nranges, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/R/Weibull.R
+++ b/R/Weibull.R
@@ -224,7 +224,7 @@ cdf.Weibull <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @family Weibull distribution
 #'
 quantile.Weibull <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
-  FUN <- function(at, d) qweibull(p = at, shape = x$shape, scale = x$scale, ...)
+  FUN <- function(at, d) qweibull(p = at, shape = d$shape, scale = d$scale, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
 

--- a/man/Exponential.Rd
+++ b/man/Exponential.Rd
@@ -28,11 +28,11 @@ will render with additional detail and much greater clarity.
 In the following, let \eqn{X} be an Exponential random variable with
 rate parameter \code{rate} = \eqn{\lambda}.
 
-\strong{Support}: {x in [0, \eqn{\infty})}
+\strong{Support}: \eqn{x \in (0, \infty)}
 
-\strong{Mean}: 1 / \eqn{\lambda}
+\strong{Mean}: \eqn{\frac{1}{\lambda}}
 
-\strong{Variance}: 1 / \eqn{\lambda^2}
+\strong{Variance}: \eqn{\frac{1}{\lambda^2}}
 
 \strong{Probability density function (p.d.f)}:
 


### PR DESCRIPTION
I noticed that some `quantile()` and `random()` methods for certain distributions don't pass on the distribution vector as intended.  This typically looked something like this:

```
quantile.dist <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
  FUN <- function(at, d) qdist(at, par = x$par, ...)
  apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
}
```

Note that `x$par` is passed on in `FUN(at, d)` rather than `d$par`. This never leads to any problems, though, because through lexical scoping the correct distribution vector is found nevertheless. But to employ standard scoping, I changed all of the occurrences to `d$par` for a number of distributions.

Finally, I made a small improvement in the `?Exponential` documentation which addresses the "Lost braces" NOTE we get in the current [CRAN checks](https://CRAN.R-project.org/web/checks/check_results_distributions3.html).