### PR TITLE
fix math rendering on site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,6 +11,7 @@ template:
     twitter:
       creator: "@alexpghayes"
       card: summary
+  math-rendering: "mathjax"
 
 reference:
   - title: "Generic functions for S3 distribution objects"


### PR DESCRIPTION
This PR changes the math rendering in pkgdown to use MathJax (the previous default).

At some point pkgdown changed how they rendered things which breaks a lot of equations on the site (e.g. https://alexpghayes.github.io/distributions3/reference/Normal.html). See https://github.com/r-lib/pkgdown/issues/2704#issuecomment-2853492054 for further discussion.

This commit returns things to the old MathJax default. I've tested this locally and it seems to fix things.