### PR TITLE
empirical test of moment computations

### DIFF
--- a/tests/testthat/test-Exponential.R
+++ b/tests/testthat/test-Exponential.R
@@ -81,6 +81,18 @@ test_that("{moments}.Exponential work correctly", {
   expect_equal(kurtosis(e), 6)
 })
 
+test_that("{moments}.Exponential is close to simulated values", {
+  skwnss <- function(x) { x <- x - mean(x); y <- sqrt(length(x)) * sum(x^3)/(sum(x^2)^(3/2)); y * ((1 - 1/length(x)))^(3/2) }
+  krtss <- function(x) { x <- x - mean(x); length(x) * sum(x^4)/(sum(x^2)^2) * (1 - 1/length(x))^2 - 3 }
+  e <- Exponential()
+  set.seed(0)
+  x <- random(e, 1e5)
+  expect_equal(mean(e), mean(x), tolerance = 1e-2)
+  expect_equal(sqrt(variance(e)), sd(x), tolerance = 1e-2)
+  expect_equal(skewness(e), skwnss(x), tolerance = 1e-4)
+  expect_equal(kurtosis(e), krtss(x), tolerance = 1e-4)
+})
+
 test_that("vectorization of a Exponential distribution work correctly", {
   d <- Exponential(c(1, 2))
   d1 <- d[1]

--- a/tests/testthat/test-Exponential.R
+++ b/tests/testthat/test-Exponential.R
@@ -84,13 +84,13 @@ test_that("{moments}.Exponential work correctly", {
 test_that("{moments}.Exponential is close to simulated values", {
   skwnss <- function(x) { x <- x - mean(x); y <- sqrt(length(x)) * sum(x^3)/(sum(x^2)^(3/2)); y * ((1 - 1/length(x)))^(3/2) }
   krtss <- function(x) { x <- x - mean(x); length(x) * sum(x^4)/(sum(x^2)^2) * (1 - 1/length(x))^2 - 3 }
-  e <- Exponential()
-  set.seed(0)
-  x <- random(e, 1e5)
-  expect_equal(mean(e), mean(x), tolerance = 1e-2)
-  expect_equal(sqrt(variance(e)), sd(x), tolerance = 1e-2)
-  expect_equal(skewness(e), skwnss(x), tolerance = 1e-4)
-  expect_equal(kurtosis(e), krtss(x), tolerance = 1e-4)
+  d <- Exponential(c(0.5, 1, 2))
+  set.seed(1)
+  x <- random(d, 1e5)
+  expect_equal(mean(d), apply(x, 1, mean), tolerance = 1e-2)
+  expect_equal(sqrt(variance(d)), apply(x, 1, sd), tolerance = 1e-2)
+  expect_equal(skewness(d), apply(x, 1, skwnss), tolerance = 5e-2)
+  expect_equal(kurtosis(d), apply(x, 1, krtss), tolerance = 5e-2)
 })
 
 test_that("vectorization of a Exponential distribution work correctly", {


### PR DESCRIPTION
As discussed in #114 it might be useful to add tests for the analytic moment computations by comparing them with empirical computations based on simulated observations.

In this PR I propose one such test for the exponential distribution. To be able to compare skewness and kurtosis I've added very short functions `skwnss()` and `krtss()` that are inspired by `e1071::skewness()` and `e1071::kurtosis()` but boiled down to the bare essentials.

Alex @alexpghayes, I think it would be relatively straightforward to add similar tests for most distributions. Questions:

- Do you consider this useful? Or is it too limited to be worth the effort (due to the high tolerances)?
- Where should I put the skewness and kurtosis functions? Should these be internal or exported? If the latter, what should they be called?