### PR TITLE
[streamline] Adding defaults to all constructor functions, updating methods to work with zero-length distribution objects, tests

### DIFF
--- a/R/Bernoulli.R
+++ b/R/Bernoulli.R
@@ -96,6 +96,7 @@ Bernoulli <- function(p = 0.5) {
 #' @export
 mean.Bernoulli <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   setNames(x$p, names(x))
 }
 
@@ -240,6 +241,7 @@ cdf.Bernoulli <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Bernoulli <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qbinom(at, size = 1, prob = d$p, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Beta.R
+++ b/R/Beta.R
@@ -47,6 +47,7 @@ Beta <- function(alpha = 1, beta = 1) {
 #' @export
 mean.Beta <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$alpha / (x$alpha + x$beta)
   setNames(rval, names(x))
 }
@@ -196,6 +197,7 @@ cdf.Beta <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Beta <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qbeta(at, shape1 = d$alpha, shape2 = d$beta, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Binomial.R
+++ b/R/Binomial.R
@@ -106,6 +106,7 @@ Binomial <- function(size = numeric(), p = 0.5) {
 #' @export
 mean.Binomial <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$size * x$p
   setNames(rval, names(x))
 }
@@ -253,6 +254,7 @@ cdf.Binomial <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Binomial <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qbinom(at, size = d$size, prob = d$p, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Binomial.R
+++ b/R/Binomial.R
@@ -90,7 +90,8 @@
 #'
 #' cdf(X, quantile(X, 0.7))
 #' quantile(X, cdf(X, 7))
-Binomial <- function(size, p = 0.5) {
+Binomial <- function(size = numeric(), p = 0.5) {
+  if (identical(size, numeric())) p <- numeric() # Ensure empty default
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =
       length(size) == length(p) | length(size) == 1 | length(p) == 1

--- a/R/Categorical.R
+++ b/R/Categorical.R
@@ -37,7 +37,7 @@
 #'
 #' # same for quantiles. this also errors!
 #' # quantile(Y, 0.7)
-Categorical <- function(outcomes, p = NULL) {
+Categorical <- function(outcomes = numeric(), p = NULL) {
   if (!is.null(p) && length(outcomes) != length(p)) {
     stop("`outcomes` and `p` must be the same length.", call. = FALSE)
   }

--- a/R/Categorical.R
+++ b/R/Categorical.R
@@ -55,30 +55,19 @@ Categorical <- function(outcomes = numeric(), p = NULL) {
 
 #' @export
 print.Categorical <- function(x, ...) {
+  if (length(x) == 0L) return(NextMethod())
   num_categories <- length(x$outcomes)
 
   if (num_categories > 3) {
-    outcomes <- paste(
-      c(x$outcomes[1:2], "...", x$outcomes[num_categories]),
-      collapse = ", "
-    )
-
-    p <- paste(
-      c(round(x$p, 3)[1:2], "...", round(x$p, 3)[num_categories]),
-      collapse = ", "
-    )
+    outcomes <- paste(c(x$outcomes[1:2], "...", x$outcomes[num_categories]), collapse = ", ")
+    p <- paste(c(round(x$p, 3)[1:2], "...", round(x$p, 3)[num_categories]),  collapse = ", ")
   } else {
     outcomes <- paste(x$outcomes, collapse = ", ")
     p <- paste(round(x$p, 3), collapse = ", ")
   }
 
-  cat(
-    sprintf(
-      "Categorical distribution\n  outcomes = [%s]\n  p = [%s]",
-      outcomes, p
-    ),
-    "\n"
-  )
+  cat(sprintf("Categorical distribution\n  outcomes = [%s]\n  p = [%s]",
+      outcomes, p), "\n")
 }
 
 #' Draw a random sample from a Categorical distribution
@@ -138,9 +127,7 @@ log_pdf.Categorical <- function(d, x, ...) {
 #' @export
 #'
 cdf.Categorical <- function(d, x, ...) {
-  if (length(x) == 0) {
-    return(numeric(0))
-  }
+  if (length(x) == 0) return(numeric(0))
 
   if (!is.numeric(d$outcomes)) {
     stop(
@@ -169,6 +156,7 @@ cdf.Categorical <- function(d, x, ...) {
 #' @export
 quantile.Categorical <- function(x, probs, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   if (!is.numeric(x$outcomes)) {
     stop(
       "The sample space of `x` must be numeric to evaluate quantiles.",

--- a/R/Cauchy.R
+++ b/R/Cauchy.R
@@ -87,6 +87,7 @@ Cauchy <- function(location = 0, scale = 1) {
 #' @importFrom rlang check_dots_used
 #' @export
 mean.Cauchy <- function(x, ...) {
+  if (!length(x)) return(numeric())
   check_dots_used()
   rval <- rep(NaN, length(x))
   setNames(rval, names(x))
@@ -229,6 +230,7 @@ cdf.Cauchy <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Cauchy <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qcauchy(at, location = d$location, scale = d$scale, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/ChiSquare.R
+++ b/R/ChiSquare.R
@@ -93,7 +93,7 @@
 #'
 #' cdf(X, quantile(X, 0.7))
 #' quantile(X, cdf(X, 7))
-ChiSquare <- function(df) {
+ChiSquare <- function(df = numeric()) {
   d <- data.frame(df = df)
   class(d) <- c("ChiSquare", "distribution")
   d

--- a/R/ChiSquare.R
+++ b/R/ChiSquare.R
@@ -103,6 +103,7 @@ ChiSquare <- function(df = numeric()) {
 #' @export
 mean.ChiSquare <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$df
   setNames(rval, names(x))
 }
@@ -245,6 +246,7 @@ cdf.ChiSquare <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.ChiSquare <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   # TODO: in the documentation, more information on return and
   # how quantiles are calculated
   FUN <- function(at, d) qchisq(at, df = d$df, ...)

--- a/R/Empirical.R
+++ b/R/Empirical.R
@@ -136,7 +136,10 @@
 #'
 #' @family Empirical distribution
 #' @export
-Empirical <- function(sample) {
+Empirical <- function(sample = numeric()) {
+  if (identical(sample, numeric()))
+      return(structure(data.frame(sample), class = c("Empirical", "distribution")))
+
   if (is.data.frame(sample)) sample <- as.matrix(sample)
   ## If input is given as a list of vectors
   if (is.list(sample) && all(sapply(sample, function(sample) is.vector(sample) && !is.matrix(sample)))) {

--- a/R/Empirical.R
+++ b/R/Empirical.R
@@ -392,6 +392,7 @@ rempirical <- function(n, y, na.rm = TRUE) {
 #' @rdname Empirical
 mean.Empirical <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   setNames(rowMeans(as.matrix(x), na.rm = TRUE), names(x))
 }
 
@@ -588,6 +589,7 @@ cdf.Empirical <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Empirical <- function(x, probs, drop = TRUE, elementwise = NULL, type = 1L, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qempirical(at, y = as.matrix(d), type = type, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }
@@ -599,7 +601,7 @@ quantile.Empirical <- function(x, probs, drop = TRUE, elementwise = NULL, type =
 ####        digits are used.
 #' @exportS3Method
 format.Empirical <- function(x, digits = pmax(3L, getOption("digits") - 3L), ...) {
-  if (length(x) < 1L) return(character(0))
+  if (!length(x)) return(character(0))
   n <- names(x)
   if (is.null(attr(x, "row.names"))) attr(x, "row.names") <- 1L:length(x)
   fn  <- function(x) c(min = min(x, na.rm = TRUE), max = max(x, na.rm = TRUE), n = sum(is.finite(x)))

--- a/R/Erlang.R
+++ b/R/Erlang.R
@@ -162,6 +162,7 @@ cdf.Erlang <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Erlang <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qgamma(p = at, shape = d$k, rate = d$lambda, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Erlang.R
+++ b/R/Erlang.R
@@ -32,7 +32,7 @@
 #'
 #' cdf(X, quantile(X, 0.7))
 #' quantile(X, cdf(X, 7))
-Erlang <- function(k, lambda) {
+Erlang <- function(k = numeric(), lambda = numeric()) {
   stopifnot("'k' must be an integer" = all(abs(k - as.integer(k)) == 0))
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =

--- a/R/Exponential.R
+++ b/R/Exponential.R
@@ -80,6 +80,7 @@ Exponential <- function(rate = 1) {
 #' @export
 mean.Exponential <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$rate^-1
   setNames(rval, names(x))
 }
@@ -221,6 +222,7 @@ cdf.Exponential <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Exponential <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qexp(at, rate = d$rate, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/FisherF.R
+++ b/R/FisherF.R
@@ -35,7 +35,8 @@
 #'
 #' cdf(X, quantile(X, 0.7))
 #' quantile(X, cdf(X, 7))
-FisherF <- function(df1, df2, lambda = 0) {
+FisherF <- function(df1 = numeric(), df2 = numeric(), lambda = 0) {
+  if (identical(df1, numeric()) && identical(df2, numeric())) lambda <- numeric()
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =
       length(df1) == length(df2) & length(df1) == length(lambda) |

--- a/R/FisherF.R
+++ b/R/FisherF.R
@@ -54,6 +54,7 @@ FisherF <- function(df1 = numeric(), df2 = numeric(), lambda = 0) {
 #' @export
 mean.FisherF <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
 
   # The k-th moment of an F(df1, df2) distribution exists and
   # is finite only when 2k < d2
@@ -226,6 +227,7 @@ cdf.FisherF <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.FisherF <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qf(at, df1 = d$df1, df2 = d$df2, ncp = d$lambda, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Frechet.R
+++ b/R/Frechet.R
@@ -95,6 +95,7 @@ Frechet <- function(location = 0, scale = 1, shape = 1) {
 #' @export
 mean.Frechet <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   a <- x$shape
   m <- x$location
   s <- x$scale
@@ -300,6 +301,7 @@ cdf.Frechet <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Frechet <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   # Convert to the GEV parameterisation
   FUN <- function(at, d) {
     loc <- x$location + x$scale

--- a/R/Gamma.R
+++ b/R/Gamma.R
@@ -94,6 +94,7 @@ Gamma <- function(shape = numeric(), rate = 1) {
 #' @export
 mean.Gamma <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$shape / x$rate
   setNames(rval, names(x))
 }
@@ -235,6 +236,7 @@ cdf.Gamma <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Gamma <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qgamma(at, shape = d$shape, rate = d$rate, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Gamma.R
+++ b/R/Gamma.R
@@ -79,7 +79,8 @@
 #'
 #' cdf(X, quantile(X, 0.7))
 #' quantile(X, cdf(X, 7))
-Gamma <- function(shape, rate = 1) {
+Gamma <- function(shape = numeric(), rate = 1) {
+  if (identical(shape, numeric())) rate <- numeric()
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =
       length(shape) == length(rate) | length(shape) == 1 | length(rate) == 1

--- a/R/GeneralisedExtremeValue.R
+++ b/R/GeneralisedExtremeValue.R
@@ -124,6 +124,7 @@ g <- function(d, k) gamma(1 - k * d$xi)
 #' @export
 mean.GEV <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   euler <- -digamma(1)
   rval <- ifelse(x$xi == 0,
     x$mu + x$sigma * euler,
@@ -307,6 +308,7 @@ cdf.GEV <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.GEV <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) revdbayes::qgev(p = at, loc = d$mu, scale = d$sigma, shape = d$xi, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/GeneralisedPareto.R
+++ b/R/GeneralisedPareto.R
@@ -114,6 +114,7 @@ GP <- function(mu = 0, sigma = 1, xi = 0) {
 #' @export
 mean.GP <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   mu <- x$mu
   sigma <- x$sigma
   xi <- x$xi
@@ -282,6 +283,7 @@ cdf.GP <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.GP <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) revdbayes::qgp(p = at, loc = d$mu, scale = d$sigma, shape = d$xi, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Geometric.R
+++ b/R/Geometric.R
@@ -74,6 +74,7 @@ Geometric <- function(p = 0.5) {
 #' @export
 mean.Geometric <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- (1 - x$p) / x$p
   setNames(rval, names(x))
 }
@@ -228,6 +229,7 @@ cdf.Geometric <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Geometric <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qgeom(p = at, prob = d$p, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Gumbel.R
+++ b/R/Gumbel.R
@@ -82,6 +82,7 @@ Gumbel <- function(mu = 0, sigma = 1) {
 #' @export
 mean.Gumbel <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$mu + x$sigma * -digamma(1)
   setNames(rval, names(x))
 }
@@ -224,6 +225,7 @@ cdf.Gumbel <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Gumbel <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) revdbayes::qgev(p = at, loc = d$mu, scale = d$sigma, shape = 0, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/HurdleNegativeBinomial.R
+++ b/R/HurdleNegativeBinomial.R
@@ -1,5 +1,5 @@
 #' The hurdle negative binomial distribution
-#' 
+#'
 #' Density, distribution function, quantile function, and random
 #' generation for the zero-hurdle negative binomial distribution with
 #' parameters \code{mu}, \code{theta} (or \code{size}), and \code{pi}.
@@ -10,7 +10,7 @@
 #' functions for the negative binomial distribution from base R internally.
 #'
 #' Note, however, that the precision of \code{qhnbinom} for very large
-#' probabilities (close to 1) is limited because the probabilities 
+#' probabilities (close to 1) is limited because the probabilities
 #' are internally handled in levels and not in logs (even if \code{log.p = TRUE}).
 #'
 #' @aliases dhnbinom phnbinom qhnbinom rhnbinom
@@ -27,7 +27,7 @@
 #' @param lower.tail logical indicating whether probabilities are \eqn{P[X \le x]} (lower tail) or \eqn{P[X > x]} (upper tail).
 #'
 #' @seealso \code{\link{HurdleNegativeBinomial}}, \code{\link{dnbinom}}
-#' 
+#'
 #' @keywords distribution
 #'
 #' @examples
@@ -35,7 +35,7 @@
 #' x <- 0:8
 #' p <- dhnbinom(x, mu = 2.5, theta = 1, pi = 0.75)
 #' plot(x, p, type = "h", lwd = 2)
-#' 
+#'
 #' ## corresponding empirical frequencies from a simulated sample
 #' set.seed(0)
 #' y <- rhnbinom(500, mu = 2.5, theta = 1, pi = 0.75)
@@ -182,7 +182,7 @@ rhnbinom <- function(n, mu, theta, size, pi) {
 #' set.seed(0)
 #' x <- random(X, 500)
 #' hist(x, breaks = -1:max(x) + 0.5)
-HurdleNegativeBinomial <- function(mu, theta, pi) {
+HurdleNegativeBinomial <- function(mu = numeric(), theta = numeric(), pi = numeric()) {
   d <- data.frame(mu = mu, theta = theta, pi = pi)
   class(d) <- c("HurdleNegativeBinomial", "distribution")
   return(d)

--- a/R/HurdleNegativeBinomial.R
+++ b/R/HurdleNegativeBinomial.R
@@ -192,6 +192,7 @@ HurdleNegativeBinomial <- function(mu = numeric(), theta = numeric(), pi = numer
 #' @export
 mean.HurdleNegativeBinomial <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$mu * x$pi / pnbinom(0, size = x$theta, mu = x$mu, lower.tail = FALSE)
   setNames(rval, names(x))
 }
@@ -345,6 +346,7 @@ cdf.HurdleNegativeBinomial <- function(d, x, drop = TRUE, elementwise = NULL, ..
 #' @export
 quantile.HurdleNegativeBinomial <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qhnbinom(p = at, mu = d$mu, theta = d$theta, pi = d$pi, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/HurdlePoisson.R
+++ b/R/HurdlePoisson.R
@@ -1,5 +1,5 @@
 #' The hurdle Poisson distribution
-#' 
+#'
 #' Density, distribution function, quantile function, and random
 #' generation for the zero-hurdle Poisson distribution with
 #' parameters \code{lambda} and \code{pi}.
@@ -10,7 +10,7 @@
 #' functions for the Poisson distribution from base R internally.
 #'
 #' Note, however, that the precision of \code{qhpois} for very large
-#' probabilities (close to 1) is limited because the probabilities 
+#' probabilities (close to 1) is limited because the probabilities
 #' are internally handled in levels and not in logs (even if \code{log.p = TRUE}).
 #'
 #' @aliases dhpois phpois qhpois rhpois
@@ -25,7 +25,7 @@
 #' @param lower.tail logical indicating whether probabilities are \eqn{P[X \le x]} (lower tail) or \eqn{P[X > x]} (upper tail).
 #'
 #' @seealso \code{\link{HurdlePoisson}}, \code{\link{dpois}}
-#' 
+#'
 #' @keywords distribution
 #'
 #' @examples
@@ -33,7 +33,7 @@
 #' x <- 0:8
 #' p <- dhpois(x, lambda = 2.5, pi = 0.75)
 #' plot(x, p, type = "h", lwd = 2)
-#' 
+#'
 #' ## corresponding empirical frequencies from a simulated sample
 #' set.seed(0)
 #' y <- rhpois(500, lambda = 2.5, pi = 0.75)
@@ -121,7 +121,7 @@ rhpois <- function(n, lambda, pi) {
 #'
 #'   **Support**: \eqn{\{0, 1, 2, 3, ...\}}{{0, 1, 2, 3, ...}}
 #'
-#'   **Mean**: 
+#'   **Mean**:
 #'   \deqn{
 #'     \lambda \cdot \frac{\pi}{1 - e^{-\lambda}}
 #'   }{
@@ -175,7 +175,7 @@ rhpois <- function(n, lambda, pi) {
 #' set.seed(0)
 #' x <- random(X, 500)
 #' hist(x, breaks = -1:max(x) + 0.5)
-HurdlePoisson <- function(lambda, pi) {
+HurdlePoisson <- function(lambda = numeric(), pi = numeric()) {
   d <- data.frame(lambda = lambda, pi = pi)
   class(d) <- c("HurdlePoisson", "distribution")
   return(d)

--- a/R/HurdlePoisson.R
+++ b/R/HurdlePoisson.R
@@ -185,6 +185,7 @@ HurdlePoisson <- function(lambda = numeric(), pi = numeric()) {
 #' @export
 mean.HurdlePoisson <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$lambda * x$pi / (1 - exp(-x$lambda))
   setNames(rval, names(x))
 }
@@ -334,6 +335,7 @@ cdf.HurdlePoisson <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.HurdlePoisson <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qhpois(p = at, lambda = d$lambda, pi = d$pi, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/HyperGeometric.R
+++ b/R/HyperGeometric.R
@@ -68,7 +68,7 @@
 #'
 #' cdf(X, 4)
 #' quantile(X, 0.7)
-HyperGeometric <- function(m, n, k) {
+HyperGeometric <- function(m = numeric(), n = numeric(), k = numeric()) {
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =
       length(m) == length(n) & length(m) == length(k) |

--- a/R/HyperGeometric.R
+++ b/R/HyperGeometric.R
@@ -110,6 +110,7 @@ HyperGeometric <- function(m = numeric(), n = numeric(), k = numeric()) {
 #' @export
 mean.HyperGeometric <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   # Reformulating to match Wikipedia
   # N is the population size
   N <- x$n + x$m
@@ -288,6 +289,7 @@ cdf.HyperGeometric <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.HyperGeometric <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qhyper(p = at, m = d$m, n = d$n, k = d$k, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/LogNormal.R
+++ b/R/LogNormal.R
@@ -73,6 +73,7 @@ LogNormal <- function(log_mu = 0, log_sigma = 1) {
 #' @export
 mean.LogNormal <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   mu <- x$log_mu
   sigma <- x$log_sigma
   rval <- exp(mu + sigma^2 / 2)
@@ -231,6 +232,7 @@ cdf.LogNormal <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.LogNormal <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qlnorm(p = at, meanlog = d$log_mu, sdlog = d$log_sigma, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Logistic.R
+++ b/R/Logistic.R
@@ -85,6 +85,7 @@ Logistic <- function(location = 0, scale = 1) {
 #' @export
 mean.Logistic <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$location
   setNames(rval, names(x))
 }
@@ -235,6 +236,7 @@ cdf.Logistic <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Logistic <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qlogis(p = at, location = d$location, scale = d$scale, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Multinomial.R
+++ b/R/Multinomial.R
@@ -99,6 +99,7 @@ print.Multinomial <- function(x, ...) {
 #' @export
 mean.Multinomial <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   x$size * x$p
 }
 

--- a/R/Multinomial.R
+++ b/R/Multinomial.R
@@ -71,9 +71,9 @@
 #'
 #' # pdf(X, 2)
 #' # log_pdf(X, 2)
-Multinomial <- function(size, p) {
+Multinomial <- function(size = numeric(), p = numeric()) {
   # Ensure sum of probabilities is 1
-  p <- p / sum(p)
+  if (length(p) > 0L) p <- p / sum(p)
   d <- list(size = size, p = p)
   class(d) <- c("Multinomial", "multivariate", "distribution")
   d
@@ -81,6 +81,7 @@ Multinomial <- function(size, p) {
 
 #' @export
 print.Multinomial <- function(x, ...) {
+  if (length(x) == 0L) return(NextMethod())
   num_categories <- length(x$p)
 
   if (num_categories > 3) {

--- a/R/NegativeBinomial.R
+++ b/R/NegativeBinomial.R
@@ -113,6 +113,7 @@ NegativeBinomial <- function(size = numeric(), p = 0.5, mu = size) {
 #' @export
 mean.NegativeBinomial <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- if("mu" %in% names(unclass(x))) {
     x$mu
   } else {
@@ -289,6 +290,7 @@ cdf.NegativeBinomial <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.NegativeBinomial <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- if("mu" %in% names(unclass(x))) {
     function(at, d) qnbinom(p = at, mu = d$mu, size = d$size, ...)
   } else {

--- a/R/NegativeBinomial.R
+++ b/R/NegativeBinomial.R
@@ -85,7 +85,8 @@
 #' Y
 #' cdf(Y, 50)
 #' quantile(Y, 0.7)
-NegativeBinomial <- function(size, p = 0.5, mu = size) {
+NegativeBinomial <- function(size = numeric(), p = 0.5, mu = size) {
+  if (identical(size, numeric())) p <- numeric()
   if(!missing(mu) && !missing(p)) stop("only one of the parameters 'p' or 'mu' must be specified")
   if(missing(mu)) {
     stopifnot("parameter 'size' must always be positive" = all(size > 0))

--- a/R/Normal.R
+++ b/R/Normal.R
@@ -170,6 +170,7 @@ Normal <- function(mu = 0, sigma = 1) {
 #' @export
 mean.Normal <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   setNames(x$mu, names(x))
 }
 
@@ -330,6 +331,7 @@ cdf.Normal <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Normal <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qnorm(at, mean = d$mu, sd = d$sigma, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Poisson.R
+++ b/R/Poisson.R
@@ -78,6 +78,7 @@ Poisson <- function(lambda = numeric()) {
 #' @export
 mean.Poisson <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$lambda
   setNames(rval, names(x))
 }
@@ -117,9 +118,7 @@ kurtosis.Poisson <- function(x, ...) {
 #'
 random.Poisson <- function(x, n = 1L, drop = TRUE, ...) {
   n <- make_positive_integer(n)
-  if (n == 0L) {
-    return(numeric(0L))
-  }
+  if (n == 0L) return(numeric())
   FUN <- function(at, d) rpois(n = at, lambda = d$lambda)
   apply_dpqr(d = x, FUN = FUN, at = n, type = "random", drop = drop)
 }
@@ -219,6 +218,7 @@ cdf.Poisson <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Poisson <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qpois(p = at, lambda = d$lambda, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Poisson.R
+++ b/R/Poisson.R
@@ -68,7 +68,7 @@
 #'
 #' cdf(X, quantile(X, 0.7))
 #' quantile(X, cdf(X, 7))
-Poisson <- function(lambda) {
+Poisson <- function(lambda = numeric()) {
   d <- data.frame(lambda = lambda)
   class(d) <- c("Poisson", "distribution")
   d

--- a/R/PoissonBinomial.R
+++ b/R/PoissonBinomial.R
@@ -142,6 +142,7 @@ format.PoissonBinomial <- function(x, digits = pmax(3L, getOption("digits") - 3L
 #' @export
 mean.PoissonBinomial <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   n <- names(x)
   rval <- rowSums(as.matrix(x), na.rm = TRUE)
   setNames(rval, n)
@@ -149,6 +150,7 @@ mean.PoissonBinomial <- function(x, ...) {
 
 #' @export
 variance.PoissonBinomial <- function(x, ...) {
+  if (length(x) == 0L) return(numeric())
   n <- names(x)
   x <- as.matrix(x)
   rval <- rowSums(x * (1 - x), na.rm = TRUE)
@@ -157,6 +159,7 @@ variance.PoissonBinomial <- function(x, ...) {
 
 #' @export
 skewness.PoissonBinomial <- function(x, ...) {
+  if (length(x) == 0L) return(numeric())
   n <- names(x)
   x <- as.matrix(x)
   v <- rowSums(x * (1 - x), na.rm = TRUE)
@@ -166,6 +169,7 @@ skewness.PoissonBinomial <- function(x, ...) {
 
 #' @export
 kurtosis.PoissonBinomial <- function(x, ...) {
+  if (length(x) == 0L) return(numeric())
   n <- names(x)
   x <- as.matrix(x)
   v <- rowSums(x * (1 - x), na.rm = TRUE)
@@ -387,18 +391,19 @@ cdf.PoissonBinomial <- function(d, x, drop = TRUE, elementwise = NULL, lower.tai
 #' @export
 quantile.PoissonBinomial <- function(x, probs, drop = TRUE, elementwise = NULL, lower.tail = TRUE, log.p = FALSE, verbose = TRUE, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   n <- length(x)
   k <- length(probs)
   if(n > 0L && k > 0L && requireNamespace("PoissonBinomial", quietly = TRUE)) {
     ## basic properties
     rnam <- names(x)
-    
+
     ## elementwise evaluation?
     if(is.null(elementwise)) elementwise <- k > 1L && k == n && is.null(dim(probs))
     if(elementwise && k > 1L && k != n) stop(
       sprintf("lengths of distribution 'x' and argument 'probs' do not match: %s != %s", n, k))
-    
-    ## apply ppbinom to each row of the parameter matrix    
+
+    ## apply ppbinom to each row of the parameter matrix
     p <- as.matrix(x)
     if (elementwise) {
       rval <- vapply(1L:n, function(i) PoissonBinomial::qpbinom(probs[i], probs = p[i,], lower.tail = lower.tail, log.p = log.p, ...), numeric(1L))

--- a/R/PoissonBinomial.R
+++ b/R/PoissonBinomial.R
@@ -104,18 +104,22 @@
 
 #' @export
 PoissonBinomial <- function(...) {
-  d <- list(...)
-  if (length(d) == 1L && is.null(dim(d))) d[[1L]] <- rbind(d[[1L]])
-  d <- do.call("cbind", d)
-  if(any(d < 0) || any(d > 1)) stop("all probabilities must be in [0, 1]")
-  d <- as.data.frame(d)
-  names(d) <- paste0("p", seq_along(d))
+  if (length(d <- list(...)) == 0L) {
+    d <- data.frame(p = numeric())
+  } else {
+    if (length(d) == 1L && is.null(dim(d))) d[[1L]] <- rbind(d[[1L]])
+    d <- do.call("cbind", d)
+    if(any(d < 0) || any(d > 1)) stop("all probabilities must be in [0, 1]")
+    d <- as.data.frame(d)
+    names(d) <- paste0("p", seq_along(d))
+  }
   class(d) <- c("PoissonBinomial", "distribution")
   d
 }
 
 #' @export
 format.PoissonBinomial <- function(x, digits = pmax(3L, getOption("digits") - 3L), cutoff = 4L, ...) {
+  if (length(x) == 0L) return(NextMethod())
   cl <- class(x)[1L]
   if (length(x) < 1L) return(character(0))
   n <- names(x)

--- a/R/ReversedWeibull.R
+++ b/R/ReversedWeibull.R
@@ -99,6 +99,7 @@ RevWeibull <- function(location = 0, scale = 1, shape = 1) {
 #' @export
 mean.RevWeibull <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$location + x$scale * gamma(1 + 1 / x$shape)
   setNames(rval, names(x))
 }
@@ -254,6 +255,7 @@ cdf.RevWeibull <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.RevWeibull <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   # Convert to the GEV parameterisation
   FUN <- function(at, d) {
     loc <- d$location - d$scale

--- a/R/StudentsT.R
+++ b/R/StudentsT.R
@@ -122,6 +122,7 @@ StudentsT <- function(df = numeric()) {
 #' @export
 mean.StudentsT <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- ifelse(x$df > 1,
     0,
     NaN
@@ -131,6 +132,7 @@ mean.StudentsT <- function(x, ...) {
 
 #' @export
 variance.StudentsT <- function(x, ...) {
+  if (length(x) == 0L) return(numeric())
   rval <- ifelse(x$df > 2,
     x$df / (x$df - 2),
     ifelse(x$df > 1,
@@ -143,6 +145,7 @@ variance.StudentsT <- function(x, ...) {
 
 #' @export
 skewness.StudentsT <- function(x, ...) {
+  if (length(x) == 0L) return(numeric())
   rval <- ifelse(x$df > 3,
     0,
     NaN
@@ -152,6 +155,7 @@ skewness.StudentsT <- function(x, ...) {
 
 #' @export
 kurtosis.StudentsT <- function(x, ...) {
+  if (length(x) == 0L) return(numeric())
   rval <- ifelse(x$df > 4,
     6 / (x$df - 4),
     ifelse(x$df > 2,
@@ -306,6 +310,7 @@ cdf.StudentsT <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.StudentsT <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qt(p = at, df = d$df, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/StudentsT.R
+++ b/R/StudentsT.R
@@ -112,7 +112,7 @@
 #' # also equivalent to
 #' mean(x) + quantile(T, 0.12 / 2) * sd(x) / sqrt(nx)
 #' mean(x) + quantile(T, 1 - 0.12 / 2) * sd(x) / sqrt(nx)
-StudentsT <- function(df) {
+StudentsT <- function(df = numeric()) {
   d <- data.frame(df = df)
   class(d) <- c("StudentsT", "distribution")
   d

--- a/R/Tukey.R
+++ b/R/Tukey.R
@@ -33,7 +33,7 @@
 #'
 #' cdf(X, 4)
 #' quantile(X, 0.7)
-Tukey <- function(nmeans, df, nranges) {
+Tukey <- function(nmeans = numeric(), df = numeric(), nranges = numeric()) {
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =
       length(nmeans) == length(df) & length(nmeans) == length(nranges) |

--- a/R/Tukey.R
+++ b/R/Tukey.R
@@ -132,6 +132,7 @@ cdf.Tukey <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Tukey <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qtukey(p = at, nmeans = d$nmeans, df = d$df, nranges = d$nranges, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/Uniform.R
+++ b/R/Uniform.R
@@ -45,6 +45,7 @@ Uniform <- function(a = 0, b = 1) {
 #' @export
 mean.Uniform <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- (x$a + x$b) / 2
   setNames(rval, names(x))
 }
@@ -213,6 +214,7 @@ cdf.Uniform <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Uniform <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) {
     qunif(
       p = at,

--- a/R/Weibull.R
+++ b/R/Weibull.R
@@ -56,7 +56,7 @@
 #'
 #' cdf(X, 4)
 #' quantile(X, 0.7)
-Weibull <- function(shape, scale) {
+Weibull <- function(shape = numeric(), scale = numeric()) {
   stopifnot(
     "parameter lengths do not match (only scalars are allowed to be recycled)" =
       length(shape) == length(scale) | length(shape) == 1 | length(scale) == 1

--- a/R/Weibull.R
+++ b/R/Weibull.R
@@ -70,6 +70,7 @@ Weibull <- function(shape = numeric(), scale = numeric()) {
 #' @export
 mean.Weibull <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   rval <- x$scale * gamma(1 + 1 / x$shape)
   setNames(rval, names(x))
 }
@@ -227,6 +228,7 @@ cdf.Weibull <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.Weibull <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qweibull(p = at, shape = d$shape, scale = d$scale, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/ZTNegativeBinomial.R
+++ b/R/ZTNegativeBinomial.R
@@ -180,6 +180,7 @@ ZTNegativeBinomial <- function(mu = numeric(), theta = numeric()) {
 #' @export
 mean.ZTNegativeBinomial <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   m <- x$mu / pnbinom(0, mu = x$mu, size = x$theta, lower.tail = FALSE)
   m[x$mu <= 0] <- 1
   setNames(m, names(x))
@@ -337,6 +338,7 @@ cdf.ZTNegativeBinomial <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.ZTNegativeBinomial <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qztnbinom(p = at, mu = d$mu, theta = d$theta, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/ZTNegativeBinomial.R
+++ b/R/ZTNegativeBinomial.R
@@ -1,5 +1,5 @@
 #' The zero-truncated negative binomial distribution
-#' 
+#'
 #' Density, distribution function, quantile function, and random
 #' generation for the zero-truncated negative binomial distribution with
 #' parameters \code{mu} and \code{theta} (or \code{size}).
@@ -26,7 +26,7 @@
 #' @param lower.tail logical indicating whether probabilities are \eqn{P[X \le x]} (lower tail) or \eqn{P[X > x]} (upper tail).
 #'
 #' @seealso \code{\link{ZTNegativeBinomial}}, \code{\link{dnbinom}}
-#' 
+#'
 #' @keywords distribution
 #'
 #' @examples
@@ -34,7 +34,7 @@
 #' x <- 0:8
 #' p <- dztnbinom(x, mu = 2.5, theta = 1)
 #' plot(x, p, type = "h", lwd = 2)
-#' 
+#'
 #' ## corresponding empirical frequencies from a simulated sample
 #' set.seed(0)
 #' y <- rztnbinom(500, mu = 2.5, theta = 1)
@@ -170,7 +170,7 @@ rztnbinom <- function(n, mu, theta, size) {
 #' set.seed(0)
 #' x <- random(X, 500)
 #' hist(x, breaks = -1:max(x) + 0.5)
-ZTNegativeBinomial <- function(mu, theta) {
+ZTNegativeBinomial <- function(mu = numeric(), theta = numeric()) {
   d <- data.frame(mu = mu, theta = theta)
   class(d) <- c("ZTNegativeBinomial", "distribution")
   return(d)

--- a/R/ZTPoisson.R
+++ b/R/ZTPoisson.R
@@ -172,6 +172,7 @@ ZTPoisson <- function(lambda = numeric()) {
 #' @export
 mean.ZTPoisson <- function(x, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   m <- x$lambda/ppois(0, lambda = x$lambda, lower.tail = FALSE)
   m[x$lambda <= 0] <- 1
   setNames(m, names(x))
@@ -324,6 +325,7 @@ cdf.ZTPoisson <- function(d, x, drop = TRUE, elementwise = NULL, ...) {
 #' @export
 quantile.ZTPoisson <- function(x, probs, drop = TRUE, elementwise = NULL, ...) {
   check_dots_used()
+  if (!length(x)) return(numeric())
   FUN <- function(at, d) qztpois(p = at, lambda = d$lambda, ...)
   apply_dpqr(d = x, FUN = FUN, at = probs, type = "quantile", drop = drop, elementwise = elementwise)
 }

--- a/R/ZTPoisson.R
+++ b/R/ZTPoisson.R
@@ -1,5 +1,5 @@
 #' The zero-truncated Poisson distribution
-#' 
+#'
 #' Density, distribution function, quantile function, and random
 #' generation for the zero-truncated Poisson distribution with
 #' parameter \code{lambda}.
@@ -24,7 +24,7 @@
 #' @param lower.tail logical indicating whether probabilities are \eqn{P[X \le x]} (lower tail) or \eqn{P[X > x]} (upper tail).
 #'
 #' @seealso \code{\link{ZTPoisson}}, \code{\link{dpois}}
-#' 
+#'
 #' @keywords distribution
 #'
 #' @examples
@@ -32,7 +32,7 @@
 #' x <- 0:8
 #' p <- dztpois(x, lambda = 2.5)
 #' plot(x, p, type = "h", lwd = 2)
-#' 
+#'
 #' ## corresponding empirical frequencies from a simulated sample
 #' set.seed(0)
 #' y <- rztpois(500, lambda = 2.5)
@@ -104,7 +104,7 @@ rztpois <- function(n, lambda) {
 #'
 #'   **Support**: \eqn{\{1, 2, 3, ...\}}{{1, 2, 3, ...}}
 #'
-#'   **Mean**: 
+#'   **Mean**:
 #'   \deqn{
 #'     \lambda \cdot \frac{1}{1 - e^{-\lambda}}
 #'   }{
@@ -162,7 +162,7 @@ rztpois <- function(n, lambda) {
 #' set.seed(0)
 #' x <- random(X, 500)
 #' hist(x, breaks = -1:max(x) + 0.5)
-ZTPoisson <- function(lambda) {
+ZTPoisson <- function(lambda = numeric()) {
   d <- data.frame(lambda = lambda)
   class(d) <- c("ZTPoisson", "distribution")
   return(d)

--- a/R/distribution.R
+++ b/R/distribution.R
@@ -320,6 +320,8 @@
 #' @rdname pdf.distribution
 #' @exportS3Method
 pdf.distribution <- function(d, x, drop = TRUE, elementwise = NULL, log = FALSE, applyfun = NULL, cores = NULL, ...) {
+    if (!length(d)) return(numeric())
+
     # To be able to numerically approximate the pdf the object must have
     # a cdf method. If not available, exit.
     cls <- setdiff(class(d), "distribution")
@@ -507,6 +509,7 @@ quantile.distribution <- function(x, probs, drop = TRUE, elementwise = NULL,
                                   upper = +1 / sqrt(.Machine$double.eps),
                                   tol   = .Machine$double.eps^0.5, maxit = 1e3, ...) {
     check_dots_used()
+    if (!length(x)) return(numeric())
 
     ## Check which S3 methods are available
     cls <- setdiff(class(x), "distribution")
@@ -715,6 +718,8 @@ quantile.distribution <- function(x, probs, drop = TRUE, elementwise = NULL,
 #' @rdname pdf.distribution
 #' @exportS3Method
 cdf.distribution <- function(d, x, drop = TRUE, elementwise = NULL, lower.tail = TRUE, ...) {
+    if (!length(d)) return(numeric())
+
     # To be able to numerically approximate the cdf the object must have
     # a pdf method. If not available, exit.
     cls <- setdiff(class(d), "distribution")
@@ -1075,6 +1080,7 @@ distribution_calculate_moments <- function(x, what, gridsize = 500L, batchsize =
 #' @exportS3Method
 #' @export random.distribution
 random.distribution <- function(x, n = 1L, drop = TRUE, ...) {
+  if (!length(x)) return(numeric())
   n <- make_positive_integer(n)
   if (n == 0L) return(numeric(0L))
   FUN <- function(at, d) quantile(d, runif(n = at))
@@ -1180,6 +1186,7 @@ random.distribution <- function(x, n = 1L, drop = TRUE, ...) {
 #' @exportS3Method
 mean.distribution <- function(x, ...) {
     check_dots_used()
+    if (!length(x)) return(numeric())
     distribution_calculate_moments(x = x, what = 1L, ...)
 }
 
@@ -1187,6 +1194,7 @@ mean.distribution <- function(x, ...) {
 #' @rdname mean.distribution
 #' @exportS3Method
 variance.distribution <- function(x, ...) {
+    if (!length(x)) return(numeric())
     distribution_calculate_moments(x = x, what = 2L, ...)
 }
 
@@ -1194,6 +1202,7 @@ variance.distribution <- function(x, ...) {
 #' @rdname mean.distribution
 #' @exportS3Method
 skewness.distribution <- function(x, ...) {
+    if (!length(x)) return(numeric())
     distribution_calculate_moments(x = x, what = 3L, ...)
 }
 
@@ -1201,6 +1210,7 @@ skewness.distribution <- function(x, ...) {
 #' @rdname mean.distribution
 #' @exportS3Method
 kurtosis.distribution <- function(x, ...) {
+    if (!length(x)) return(numeric())
     distribution_calculate_moments(x = x, what = 4L, ...)
 }
 

--- a/R/is_discrete.R
+++ b/R/is_discrete.R
@@ -33,6 +33,7 @@
 #' @export
 is_discrete <- function(d, ...) {
   check_dots_used()
+  if (!length(d)) return(logical())
   UseMethod("is_discrete")
 }
 
@@ -41,5 +42,6 @@ is_discrete <- function(d, ...) {
 #' @export
 is_continuous <- function(d, ...) {
   check_dots_used()
+  if (!length(d)) return(logical())
   UseMethod("is_continuous")
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -43,6 +43,7 @@
 #' @export
 random <- function(x, n = 1L, drop = TRUE, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("random")
 }
 
@@ -103,6 +104,7 @@ simulate.distribution <- function(object, nsim = 1L, seed = NULL, ...) {
 #' @export
 pdf <- function(d, x, drop = TRUE, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("pdf")
 }
 
@@ -111,6 +113,7 @@ pdf <- function(d, x, drop = TRUE, ...) {
 #' @export
 log_pdf <- function(d, x, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("log_pdf")
 }
 
@@ -145,6 +148,7 @@ pmf <- function(d, x, ...) {
 #' @export
 cdf <- function(d, x, drop = TRUE, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("cdf")
 }
 
@@ -175,6 +179,7 @@ cdf <- function(d, x, drop = TRUE, ...) {
 #' @export
 variance <- function(x, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("variance")
 }
 
@@ -183,6 +188,7 @@ variance <- function(x, ...) {
 #' @export
 skewness <- function(x, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("skewness")
 }
 
@@ -191,6 +197,7 @@ skewness <- function(x, ...) {
 #' @export
 kurtosis <- function(x, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("kurtosis")
 }
 
@@ -246,6 +253,7 @@ likelihood <- function(d, x, ...) {
 #' @export
 fit_mle <- function(d, x, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("fit_mle")
 }
 
@@ -266,6 +274,7 @@ fit_mle <- function(d, x, ...) {
 #' @export
 suff_stat <- function(d, x, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("suff_stat")
 }
 
@@ -293,5 +302,6 @@ suff_stat <- function(d, x, ...) {
 #' @export
 support <- function(d, drop = TRUE, ...) {
   check_dots_used()
+  if (!length(d)) return(numeric())
   UseMethod("support")
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -43,7 +43,7 @@
 #' @export
 random <- function(x, n = 1L, drop = TRUE, ...) {
   check_dots_used()
-  if (!length(d)) return(numeric())
+  if (!length(x)) return(numeric())
   UseMethod("random")
 }
 
@@ -179,7 +179,7 @@ cdf <- function(d, x, drop = TRUE, ...) {
 #' @export
 variance <- function(x, ...) {
   check_dots_used()
-  if (!length(d)) return(numeric())
+  if (!length(x)) return(numeric())
   UseMethod("variance")
 }
 
@@ -188,7 +188,7 @@ variance <- function(x, ...) {
 #' @export
 skewness <- function(x, ...) {
   check_dots_used()
-  if (!length(d)) return(numeric())
+  if (!length(x)) return(numeric())
   UseMethod("skewness")
 }
 
@@ -197,7 +197,7 @@ skewness <- function(x, ...) {
 #' @export
 kurtosis <- function(x, ...) {
   check_dots_used()
-  if (!length(d)) return(numeric())
+  if (!length(x)) return(numeric())
   UseMethod("kurtosis")
 }
 

--- a/man/Binomial.Rd
+++ b/man/Binomial.Rd
@@ -4,7 +4,7 @@
 \alias{Binomial}
 \title{Create a Binomial distribution}
 \usage{
-Binomial(size, p = 0.5)
+Binomial(size = numeric(), p = 0.5)
 }
 \arguments{
 \item{size}{The number of trials. Must be an integer greater than or equal

--- a/man/Categorical.Rd
+++ b/man/Categorical.Rd
@@ -4,7 +4,7 @@
 \alias{Categorical}
 \title{Create a Categorical distribution}
 \usage{
-Categorical(outcomes, p = NULL)
+Categorical(outcomes = numeric(), p = NULL)
 }
 \arguments{
 \item{outcomes}{A vector specifying the elements in the sample

--- a/man/ChiSquare.Rd
+++ b/man/ChiSquare.Rd
@@ -4,7 +4,7 @@
 \alias{ChiSquare}
 \title{Create a Chi-Square distribution}
 \usage{
-ChiSquare(df)
+ChiSquare(df = numeric())
 }
 \arguments{
 \item{df}{Degrees of freedom. Must be positive.}

--- a/man/Empirical.Rd
+++ b/man/Empirical.Rd
@@ -8,7 +8,7 @@
 \alias{kurtosis.Empirical}
 \title{Create an Empirical distribution}
 \usage{
-Empirical(sample)
+Empirical(sample = numeric())
 
 \method{mean}{Empirical}(x, ...)
 

--- a/man/Erlang.Rd
+++ b/man/Erlang.Rd
@@ -4,7 +4,7 @@
 \alias{Erlang}
 \title{Create an Erlang distribution}
 \usage{
-Erlang(k, lambda)
+Erlang(k = numeric(), lambda = numeric())
 }
 \arguments{
 \item{k}{The shape parameter. Can be any positive integer number.}

--- a/man/FisherF.Rd
+++ b/man/FisherF.Rd
@@ -4,7 +4,7 @@
 \alias{FisherF}
 \title{Create an F distribution}
 \usage{
-FisherF(df1, df2, lambda = 0)
+FisherF(df1 = numeric(), df2 = numeric(), lambda = 0)
 }
 \arguments{
 \item{df1}{Numerator degrees of freedom. Can be any positive number.}

--- a/man/Gamma.Rd
+++ b/man/Gamma.Rd
@@ -4,7 +4,7 @@
 \alias{Gamma}
 \title{Create a Gamma distribution}
 \usage{
-Gamma(shape, rate = 1)
+Gamma(shape = numeric(), rate = 1)
 }
 \arguments{
 \item{shape}{The shape parameter. Can be any positive number.}

--- a/man/HurdleNegativeBinomial.Rd
+++ b/man/HurdleNegativeBinomial.Rd
@@ -4,7 +4,7 @@
 \alias{HurdleNegativeBinomial}
 \title{Create a hurdle negative binomial distribution}
 \usage{
-HurdleNegativeBinomial(mu, theta, pi)
+HurdleNegativeBinomial(mu = numeric(), theta = numeric(), pi = numeric())
 }
 \arguments{
 \item{mu}{Location parameter of the negative binomial component of the distribution.

--- a/man/HurdlePoisson.Rd
+++ b/man/HurdlePoisson.Rd
@@ -4,7 +4,7 @@
 \alias{HurdlePoisson}
 \title{Create a hurdle Poisson distribution}
 \usage{
-HurdlePoisson(lambda, pi)
+HurdlePoisson(lambda = numeric(), pi = numeric())
 }
 \arguments{
 \item{lambda}{Parameter of the Poisson component of the distribution.

--- a/man/HyperGeometric.Rd
+++ b/man/HyperGeometric.Rd
@@ -4,7 +4,7 @@
 \alias{HyperGeometric}
 \title{Create a HyperGeometric distribution}
 \usage{
-HyperGeometric(m, n, k)
+HyperGeometric(m = numeric(), n = numeric(), k = numeric())
 }
 \arguments{
 \item{m}{The number of type I elements available.}

--- a/man/Multinomial.Rd
+++ b/man/Multinomial.Rd
@@ -4,7 +4,7 @@
 \alias{Multinomial}
 \title{Create a Multinomial distribution}
 \usage{
-Multinomial(size, p)
+Multinomial(size = numeric(), p = numeric())
 }
 \arguments{
 \item{size}{The number of trials. Must be an integer greater than or equal

--- a/man/NegativeBinomial.Rd
+++ b/man/NegativeBinomial.Rd
@@ -4,7 +4,7 @@
 \alias{NegativeBinomial}
 \title{Create a negative binomial distribution}
 \usage{
-NegativeBinomial(size, p = 0.5, mu = size)
+NegativeBinomial(size = numeric(), p = 0.5, mu = size)
 }
 \arguments{
 \item{size}{The target number of successes (greater than \eqn{0})

--- a/man/Poisson.Rd
+++ b/man/Poisson.Rd
@@ -4,7 +4,7 @@
 \alias{Poisson}
 \title{Create a Poisson distribution}
 \usage{
-Poisson(lambda)
+Poisson(lambda = numeric())
 }
 \arguments{
 \item{lambda}{The shape parameter, which is also the mean and the

--- a/man/StudentsT.Rd
+++ b/man/StudentsT.Rd
@@ -4,7 +4,7 @@
 \alias{StudentsT}
 \title{Create a Student's T distribution}
 \usage{
-StudentsT(df)
+StudentsT(df = numeric())
 }
 \arguments{
 \item{df}{Degrees of freedom. Can be any positive number. Often

--- a/man/Tukey.Rd
+++ b/man/Tukey.Rd
@@ -4,7 +4,7 @@
 \alias{Tukey}
 \title{Create a Tukey distribution}
 \usage{
-Tukey(nmeans, df, nranges)
+Tukey(nmeans = numeric(), df = numeric(), nranges = numeric())
 }
 \arguments{
 \item{nmeans}{Sample size for each range.}

--- a/man/Weibull.Rd
+++ b/man/Weibull.Rd
@@ -4,7 +4,7 @@
 \alias{Weibull}
 \title{Create a Weibull distribution}
 \usage{
-Weibull(shape, scale)
+Weibull(shape = numeric(), scale = numeric())
 }
 \arguments{
 \item{shape}{The shape parameter \eqn{k}. Can be any positive real number.}

--- a/man/ZTNegativeBinomial.Rd
+++ b/man/ZTNegativeBinomial.Rd
@@ -4,7 +4,7 @@
 \alias{ZTNegativeBinomial}
 \title{Create a zero-truncated negative binomial distribution}
 \usage{
-ZTNegativeBinomial(mu, theta)
+ZTNegativeBinomial(mu = numeric(), theta = numeric())
 }
 \arguments{
 \item{mu}{Location parameter of the negative binomial component of the distribution.

--- a/man/ZTPoisson.Rd
+++ b/man/ZTPoisson.Rd
@@ -4,7 +4,7 @@
 \alias{ZTPoisson}
 \title{Create a zero-truncated Poisson distribution}
 \usage{
-ZTPoisson(lambda)
+ZTPoisson(lambda = numeric())
 }
 \arguments{
 \item{lambda}{Parameter of the underlying untruncated Poisson distribution.

--- a/tests/testthat/test-Bernoulli.R
+++ b/tests/testthat/test-Bernoulli.R
@@ -1,3 +1,9 @@
+
+test_that("Bernoulli default arguments", {
+  expect_identical(formals(Bernoulli),
+    as.pairlist(alist(p = 0.5)))
+})
+
 test_that("print.Bernoulli works", {
   expect_output(print(Bernoulli()), regexp = "Bernoulli")
 })

--- a/tests/testthat/test-Beta.R
+++ b/tests/testthat/test-Beta.R
@@ -1,3 +1,9 @@
+
+test_that("Beta default arguments", {
+  expect_identical(formals(Beta),
+    as.pairlist(alist(alpha = 1, beta = 1)))
+})
+
 test_that("print.Beta works", {
   expect_output(print(Beta()), regexp = "Beta")
 })

--- a/tests/testthat/test-Binomial.R
+++ b/tests/testthat/test-Binomial.R
@@ -1,5 +1,11 @@
+
+test_that("Binomial default arguments", {
+  expect_identical(formals(Binomial),
+    as.pairlist(alist(size = numeric(), p = 0.5)))
+})
+
 test_that("print.Binomial works", {
-  expect_output(print(Binomial(1)), regexp = "Binomial")
+  expect_output(print(Binomial()), regexp = "Binomial")
 })
 
 test_that("fit_mle.Binomial works correctly", {

--- a/tests/testthat/test-Categorical.R
+++ b/tests/testthat/test-Categorical.R
@@ -1,3 +1,9 @@
+
+test_that("Categorical default arguments", {
+  expect_identical(formals(Categorical),
+    as.pairlist(alist(outcomes = numeric(), p = NULL)))
+})
+
 test_that("print.Categorical", {
   X <- Categorical(1:6)
   Y <- Categorical(LETTERS[1:3], p = c(0.1, 0.2, 0.7))

--- a/tests/testthat/test-Cauchy.R
+++ b/tests/testthat/test-Cauchy.R
@@ -1,3 +1,9 @@
+
+test_that("Cauchy default arguments", {
+  expect_identical(formals(Cauchy),
+    as.pairlist(alist(location = 0, scale = 1)))
+})
+
 test_that("print.Cauchy works", {
   expect_output(print(Cauchy(1, 1)), regexp = "Cauchy")
 })

--- a/tests/testthat/test-ChiSquare.R
+++ b/tests/testthat/test-ChiSquare.R
@@ -1,3 +1,9 @@
+
+test_that("ChiSquare default arguments", {
+  expect_identical(formals(ChiSquare),
+    as.pairlist(alist(df = numeric())))
+})
+
 test_that("print.ChiSquare works", {
   expect_output(print(ChiSquare(df = 1)), regexp = "ChiSquare")
 })

--- a/tests/testthat/test-Empirical.R
+++ b/tests/testthat/test-Empirical.R
@@ -5,8 +5,9 @@
 if (interactive()) { library("distributions3"); library("testthat") }
 suppressPackageStartupMessages(library("scoringRules"))
 
-test_that("Empirical exists", {
-    expect_true(is.function(Empirical))
+test_that("Empirical default arguments", {
+  expect_identical(formals(Empirical),
+    as.pairlist(alist(sample = numeric())))
 })
 
 test_that("Empirical unexpected input", {

--- a/tests/testthat/test-Erlang.R
+++ b/tests/testthat/test-Erlang.R
@@ -2,6 +2,12 @@
 #
 # The Erlang distribution is a special case of the gamma distribution wherein
 # the shape (k) of the distribution is discretised.
+
+test_that("Erlang default arguments", {
+  expect_identical(formals(Erlang),
+    as.pairlist(alist(k = numeric(), lambda = numeric())))
+})
+
 e <- Erlang(k = 3, lambda = 0.5)
 
 test_that("Erlang constructor works", {

--- a/tests/testthat/test-Exponential.R
+++ b/tests/testthat/test-Exponential.R
@@ -1,3 +1,9 @@
+
+test_that("Exponential default arguments", {
+  expect_identical(formals(Exponential),
+    as.pairlist(alist(rate = 1)))
+})
+
 test_that("fit_mle.Exponential works correctly", {
   expect_equal(fit_mle(Exponential(), 1), Exponential(1))
 

--- a/tests/testthat/test-FisherF.R
+++ b/tests/testthat/test-FisherF.R
@@ -1,3 +1,9 @@
+
+test_that("FisherF default arguments", {
+  expect_identical(formals(FisherF),
+    as.pairlist(alist(df1 = numeric(), df2 = numeric(), lambda = 0)))
+})
+
 test_that("print.FisherF works", {
   expect_output(print(FisherF(1, 1)), regexp = "FisherF")
 })

--- a/tests/testthat/test-Frechet.R
+++ b/tests/testthat/test-Frechet.R
@@ -1,3 +1,9 @@
+
+test_that("Frechet default arguments", {
+  expect_identical(formals(Frechet),
+    as.pairlist(alist(location = 0, scale = 1, shape = 1)))
+})
+
 test_that("print.Frechet works", {
   expect_output(print(Frechet()), regexp = "Frechet")
 })

--- a/tests/testthat/test-Gamma.R
+++ b/tests/testthat/test-Gamma.R
@@ -1,3 +1,9 @@
+
+test_that("Gamma default arguments", {
+  expect_identical(formals(Gamma),
+    as.pairlist(alist(shape = numeric(), rate = 1)))
+})
+
 test_that("print.Gamma works", {
   expect_output(print(Gamma(1, 1)), regexp = "Gamma")
 })

--- a/tests/testthat/test-GeneralisedExtremeValue.R
+++ b/tests/testthat/test-GeneralisedExtremeValue.R
@@ -1,3 +1,9 @@
+
+test_that("GEV default arguments", {
+  expect_identical(formals(GEV),
+    as.pairlist(alist(mu = 0, sigma = 1, xi = 0)))
+})
+
 test_that("print.GEV works", {
   expect_output(print(GEV()), regexp = "GEV")
 })

--- a/tests/testthat/test-GeneralisedPareto.R
+++ b/tests/testthat/test-GeneralisedPareto.R
@@ -1,3 +1,9 @@
+
+test_that("GP default arguments", {
+  expect_identical(formals(GP),
+    as.pairlist(alist(mu = 0, sigma = 1, xi = 0)))
+})
+
 test_that("print.GP works", {
   expect_output(print(GP()), regexp = "GP")
 })

--- a/tests/testthat/test-Geometric.R
+++ b/tests/testthat/test-Geometric.R
@@ -1,3 +1,9 @@
+
+test_that("Geometric default arguments", {
+  expect_identical(formals(Geometric),
+    as.pairlist(alist(p = 0.5)))
+})
+
 test_that("print.Geometric works", {
   expect_output(print(Geometric()), regexp = "Geometric")
 })

--- a/tests/testthat/test-Gumbel.R
+++ b/tests/testthat/test-Gumbel.R
@@ -1,3 +1,9 @@
+
+test_that("Gumbel default arguments", {
+  expect_identical(formals(Gumbel),
+    as.pairlist(alist(mu = 0, sigma = 1)))
+})
+
 test_that("print.Gumbel works", {
   expect_output(print(Gumbel()), regexp = "Gumbel")
 })

--- a/tests/testthat/test-HurdleNegativeBinomial.R
+++ b/tests/testthat/test-HurdleNegativeBinomial.R
@@ -1,3 +1,9 @@
+
+test_that("HurdleNegativeBinomial default arguments", {
+  expect_identical(formals(HurdleNegativeBinomial),
+    as.pairlist(alist(mu = numeric(), theta = numeric(), pi = numeric())))
+})
+
 test_that("print.HurdleNegativeBinomial works", {
   expect_output(print(HurdleNegativeBinomial(1, 1, 0.7)), regexp = "HurdleNegativeBinomial")
 })

--- a/tests/testthat/test-HurdlePoisson.R
+++ b/tests/testthat/test-HurdlePoisson.R
@@ -1,3 +1,9 @@
+
+test_that("HurdlePoisson default arguments", {
+  expect_identical(formals(HurdlePoisson),
+    as.pairlist(alist(lambda = numeric(), pi = numeric())))
+})
+
 test_that("print.HurdlePoisson works", {
   expect_output(print(HurdlePoisson(1, 0.7)), regexp = "HurdlePoisson")
 })

--- a/tests/testthat/test-HyperGeometric.R
+++ b/tests/testthat/test-HyperGeometric.R
@@ -1,3 +1,9 @@
+
+test_that("HyperGeometric default arguments", {
+  expect_identical(formals(HyperGeometric),
+    as.pairlist(alist(m = numeric(), n = numeric(), k = numeric())))
+})
+
 test_that("HyperGeometric works as intended when k > n + m", {
   expect_error(HyperGeometric(1, 1, 3))
 })

--- a/tests/testthat/test-LogNormal.R
+++ b/tests/testthat/test-LogNormal.R
@@ -1,3 +1,9 @@
+
+test_that("LogNormal default arguments", {
+  expect_identical(formals(LogNormal),
+    as.pairlist(alist(log_mu = 0, log_sigma = 1)))
+})
+
 test_that("print.LogNormal works", {
   expect_output(print(LogNormal()), regexp = "LogNormal")
 })

--- a/tests/testthat/test-Logistic.R
+++ b/tests/testthat/test-Logistic.R
@@ -1,5 +1,11 @@
+
+test_that("Logistic default arguments", {
+  expect_identical(formals(Logistic),
+    as.pairlist(alist(location = 0, scale = 1)))
+})
+
 test_that("print.Logistic works", {
-  expect_output(print(Logistic(1, 1)), regexp = "Logistic")
+  expect_output(print(Logistic()), regexp = "Logistic")
 })
 
 test_that("likelihood.Logistic and log_likelihood.Logistic work correctly", {

--- a/tests/testthat/test-Multinomial.R
+++ b/tests/testthat/test-Multinomial.R
@@ -1,3 +1,9 @@
+
+test_that("Multinomial default arguments", {
+  expect_identical(formals(Multinomial),
+    as.pairlist(alist(size = numeric(), p = numeric())))
+})
+
 test_that("print.Multinomial works", {
   expect_output(print(Multinomial(1, 0.5)), regexp = "Multinomial")
 })

--- a/tests/testthat/test-NegativeBinomial.R
+++ b/tests/testthat/test-NegativeBinomial.R
@@ -1,3 +1,9 @@
+
+test_that("NegativeBinomial default arguments", {
+  expect_identical(formals(NegativeBinomial),
+    as.pairlist(alist(size = numeric(), p = 0.5, mu = size)))
+})
+
 test_that("print.NegativeBinomial works", {
   expect_output(print(NegativeBinomial(1, 1)), regexp = "NegativeBinomial")
 })

--- a/tests/testthat/test-Normal.R
+++ b/tests/testthat/test-Normal.R
@@ -1,3 +1,9 @@
+
+test_that("Normal default arguments", {
+  expect_identical(formals(Normal),
+    as.pairlist(alist(mu = 0, sigma = 1)))
+})
+
 test_that("print.Normal works", {
   expect_output(print(Normal()), regexp = "Normal")
 })

--- a/tests/testthat/test-Poisson.R
+++ b/tests/testthat/test-Poisson.R
@@ -1,3 +1,9 @@
+
+test_that("Poisson default arguments", {
+  expect_identical(formals(Poisson),
+    as.pairlist(alist(lambda = numeric())))
+})
+
 test_that("print.Poisson works", {
   expect_output(print(Poisson(1)), regexp = "Poisson")
 })

--- a/tests/testthat/test-PoissonBinomial.R
+++ b/tests/testthat/test-PoissonBinomial.R
@@ -1,3 +1,9 @@
+
+test_that("PoissonBinomial default arguments", {
+  expect_identical(formals(PoissonBinomial),
+    as.pairlist(alist(... =)))
+})
+
 test_that("print.PoissonBinomial works", {
   expect_output(print(PoissonBinomial(0.5, 0.3, 0.8)), regexp = "PoissonBinomial")
 })

--- a/tests/testthat/test-RevWeibull.R
+++ b/tests/testthat/test-RevWeibull.R
@@ -1,3 +1,9 @@
+
+test_that("RevWeibull default arguments", {
+  expect_identical(formals(RevWeibull),
+    as.pairlist(alist(location = 0, scale = 1, shape = 1)))
+})
+
 test_that("print.RevWeibull works", {
   expect_output(print(RevWeibull()), regexp = "RevWeibull")
 })

--- a/tests/testthat/test-StudentsT.R
+++ b/tests/testthat/test-StudentsT.R
@@ -1,3 +1,9 @@
+
+test_that("StudentsT default arguments", {
+  expect_identical(formals(StudentsT),
+    as.pairlist(alist(df = numeric())))
+})
+
 test_that("print.StudentsT works", {
   expect_output(print(StudentsT(1)), regexp = "StudentsT")
 })

--- a/tests/testthat/test-Tukey.R
+++ b/tests/testthat/test-Tukey.R
@@ -1,3 +1,9 @@
+
+test_that("Tukey default arguments", {
+  expect_identical(formals(Tukey),
+    as.pairlist(alist(nmeans = numeric(), df = numeric(), nranges = numeric())))
+})
+
 test_that("print.Tukey works", {
   expect_output(print(Tukey(1, 2, 2)), regexp = "Tukey")
 })

--- a/tests/testthat/test-Uniform.R
+++ b/tests/testthat/test-Uniform.R
@@ -1,3 +1,9 @@
+
+test_that("Uniform default arguments", {
+  expect_identical(formals(Uniform),
+    as.pairlist(alist(a = 0, b = 1)))
+})
+
 test_that("print.Uniform works", {
   expect_output(print(Uniform(1, 1)), regexp = "Uniform")
 })

--- a/tests/testthat/test-Weibull.R
+++ b/tests/testthat/test-Weibull.R
@@ -1,3 +1,9 @@
+
+test_that("Weibull default arguments", {
+  expect_identical(formals(Weibull),
+    as.pairlist(alist(shape = numeric(), scale = numeric())))
+})
+
 test_that("print.Weibull works", {
   expect_output(print(Weibull(1, 1)), regexp = "Weibull")
 })

--- a/tests/testthat/test-ZTNegativeBinomial.R
+++ b/tests/testthat/test-ZTNegativeBinomial.R
@@ -1,3 +1,9 @@
+
+test_that("ZTNegativeBinomial default arguments", {
+  expect_identical(formals(ZTNegativeBinomial),
+    as.pairlist(alist(mu = numeric(), theta = numeric())))
+})
+
 test_that("print.ZTNegativeBinomial works", {
   expect_output(print(ZTNegativeBinomial(1, 1)), regexp = "ZTNegativeBinomial")
 })

--- a/tests/testthat/test-ZTPoisson.R
+++ b/tests/testthat/test-ZTPoisson.R
@@ -1,3 +1,9 @@
+
+test_that("ZTPoisson default arguments", {
+  expect_identical(formals(ZTPoisson),
+    as.pairlist(alist(lambda = numeric())))
+})
+
 test_that("print.ZTPoisson works", {
   expect_output(print(ZTPoisson(1)), regexp = "ZTPoisson")
 })

--- a/tests/testthat/test-distribution-lengt-zero.R
+++ b/tests/testthat/test-distribution-lengt-zero.R
@@ -1,0 +1,95 @@
+# -------------------------------------------------------
+# Automatically testing default behavior for
+# empty distribution objects (i.e., length 0).
+# -------------------------------------------------------
+
+if (interactive()) { library("distributions3"); library("testthat") }
+suppressPackageStartupMessages(library("scoringRules"))
+
+to_test <- c("Bernoulli", "Beta", "Cauchy", "Exponential", "Frechet", "GEV",
+             "GP", "Geometric", "Gumbel", "LogNormal", "Logistic", "Normal",
+             "RevWeibull", "Uniform", "Binomial", "Categorical", "ChiSquare",
+             "Empirical", "Erlang", "FisherF", "Gamma",
+             "HurdleNegativeBinomial", "HurdlePoisson", "HyperGeometric",
+             "Multinomial", "NegativeBinomial", "Poisson", "PoissonBinomial",
+             "StudentsT", "Tukey", "Weibull", "ZTNegativeBinomial",
+             "ZTPoisson")
+
+# Helper function
+get_zero_length_object <- function(n) {
+    FUN <- getFunction(n, where = "package:distributions3")
+
+    # PoissonBinomial has just a ... argument, thus we need to handle it differently here
+    if (n == "PoissonBinomial") return(FUN())
+
+    # Some special handling required
+    args <- switch(n,
+                   NegativeBinomial = c("size", "p"),
+                   names(formals(FUN)))
+
+    # Eval and return
+    do.call(FUN, setNames(lapply(args, function(...) numeric()), args))
+}
+
+
+test_that("returning and printing zero-length distribution objects works", {
+    for (dist in to_test) {
+        ###message(" ------ ", dist)
+        expect_silent(d <- get_zero_length_object(dist))
+
+        # Checking class and length of return
+        expect_true(inherits(d, dist),  info = paste(dist, "returns invalid object class"))
+        expect_identical(length(d), 0L, info = paste("expected", dist, "to return object of length 0"))
+        expect_output(print(d),         regexp = paste(dist, "distribution of length zero"))
+    }
+})
+
+
+test_that("distribution objects on zero-length distribution object works", {
+    for (dist in to_test) {
+        ###message(" ------ ", dist)
+        d <- get_zero_length_object(dist)
+
+        expect_identical(cdf(d, 1), numeric(),
+            info = paste0("expected NULL from cdf(<", dist, ">, 1) of zero-length object"))
+        expect_identical(pdf(d, 1), numeric(),
+            info = paste0("expected NULL from pdf(<", dist, ">, 1) of zero-length object"))
+        expect_identical(log_pdf(d, 1), numeric(),
+            info = paste0("expected NULL from log_pdf(<", dist, ">, 1) of zero-length object"))
+        expect_identical(quantile(d, 0.5), numeric(),
+            info = paste0("expected NULL from quantile(<", dist, ">, 0.5) of zero-length object"))
+    }
+})
+
+
+test_that("central moments on zero-length distribution object works", {
+    for (dist in to_test) {
+        ###message(" ------ ", dist)
+        d <- get_zero_length_object(dist)
+
+        # Central moments must return numeric()
+        expect_identical(mean(d), numeric(),
+            info = paste0("expected NULL from mean(<", dist, ">) of zero-length object"))
+        expect_identical(variance(d), numeric(),
+            info = paste0("expected NULL from variance(<", dist, ">) of zero-length object"))
+        expect_identical(skewness(d), numeric(),
+            info = paste0("expected NULL from skewness(<", dist, ">) of zero-length object"))
+        expect_identical(kurtosis(d), numeric(),
+            info = paste0("expected NULL from kurtosis(<", dist, ">) of zero-length object"))
+    }
+})
+
+
+test_that("support, is_discrete, and is_continuous on zero-length distribution object works", {
+    for (dist in to_test) {
+        ###message(" ------ ", dist)
+        d <- get_zero_length_object(dist)
+
+        expect_identical(support(d), numeric(),
+            info = paste0("expected NULL from support(<", dist, ">) of zero-length object"))
+        expect_identical(is_discrete(d), logical(),
+            info = paste0("expected NULL from is_discrete(<", dist, ">) of zero-length object"))
+        expect_identical(is_continuous(d), logical(),
+            info = paste0("expected NULL from is_continuous(<", dist, ">) of zero-length object"))
+    }
+})

--- a/tests/testthat/test-distribution-lengt-zero.R
+++ b/tests/testthat/test-distribution-lengt-zero.R
@@ -58,6 +58,8 @@ test_that("distribution objects on zero-length distribution object works", {
             info = paste0("expected NULL from log_pdf(<", dist, ">, 1) of zero-length object"))
         expect_identical(quantile(d, 0.5), numeric(),
             info = paste0("expected NULL from quantile(<", dist, ">, 0.5) of zero-length object"))
+        expect_identical(random(d), numeric(),
+            info = paste0("expected NULL from random(<", dist, ">) of zero-length object"))
     }
 })
 

--- a/tests/testthat/test-distribution-lengt-zero.R
+++ b/tests/testthat/test-distribution-lengt-zero.R
@@ -51,15 +51,15 @@ test_that("distribution objects on zero-length distribution object works", {
         d <- get_zero_length_object(dist)
 
         expect_identical(cdf(d, 1), numeric(),
-            info = paste0("expected NULL from cdf(<", dist, ">, 1) of zero-length object"))
+            info = paste0("expected numeric() from cdf(<", dist, ">, 1) of zero-length object"))
         expect_identical(pdf(d, 1), numeric(),
-            info = paste0("expected NULL from pdf(<", dist, ">, 1) of zero-length object"))
+            info = paste0("expected numeric() from pdf(<", dist, ">, 1) of zero-length object"))
         expect_identical(log_pdf(d, 1), numeric(),
-            info = paste0("expected NULL from log_pdf(<", dist, ">, 1) of zero-length object"))
+            info = paste0("expected numeric() from log_pdf(<", dist, ">, 1) of zero-length object"))
         expect_identical(quantile(d, 0.5), numeric(),
-            info = paste0("expected NULL from quantile(<", dist, ">, 0.5) of zero-length object"))
+            info = paste0("expected numeric() from quantile(<", dist, ">, 0.5) of zero-length object"))
         expect_identical(random(d), numeric(),
-            info = paste0("expected NULL from random(<", dist, ">) of zero-length object"))
+            info = paste0("expected numeric() from random(<", dist, ">) of zero-length object"))
     }
 })
 
@@ -71,13 +71,13 @@ test_that("central moments on zero-length distribution object works", {
 
         # Central moments must return numeric()
         expect_identical(mean(d), numeric(),
-            info = paste0("expected NULL from mean(<", dist, ">) of zero-length object"))
+            info = paste0("expected numeric() from mean(<", dist, ">) of zero-length object"))
         expect_identical(variance(d), numeric(),
-            info = paste0("expected NULL from variance(<", dist, ">) of zero-length object"))
+            info = paste0("expected numeric() from variance(<", dist, ">) of zero-length object"))
         expect_identical(skewness(d), numeric(),
-            info = paste0("expected NULL from skewness(<", dist, ">) of zero-length object"))
+            info = paste0("expected numeric() from skewness(<", dist, ">) of zero-length object"))
         expect_identical(kurtosis(d), numeric(),
-            info = paste0("expected NULL from kurtosis(<", dist, ">) of zero-length object"))
+            info = paste0("expected numeric() from kurtosis(<", dist, ">) of zero-length object"))
     }
 })
 
@@ -88,10 +88,25 @@ test_that("support, is_discrete, and is_continuous on zero-length distribution o
         d <- get_zero_length_object(dist)
 
         expect_identical(support(d), numeric(),
-            info = paste0("expected NULL from support(<", dist, ">) of zero-length object"))
+            info = paste0("expected numeric() from support(<", dist, ">) of zero-length object"))
         expect_identical(is_discrete(d), logical(),
-            info = paste0("expected NULL from is_discrete(<", dist, ">) of zero-length object"))
+            info = paste0("expected logical() from is_discrete(<", dist, ">) of zero-length object"))
         expect_identical(is_continuous(d), logical(),
-            info = paste0("expected NULL from is_continuous(<", dist, ">) of zero-length object"))
+            info = paste0("expected logical() from is_continuous(<", dist, ">) of zero-length object"))
     }
 })
+
+
+test_that("suff_stat and fit_mle on zero-length distribution object works", {
+    for (dist in to_test) {
+        ###message(" ------ ", dist)
+        d <- get_zero_length_object(dist)
+
+        expect_identical(suff_stat(d, 1:2), numeric(),
+            info = paste0("expected numeric() from suff_stat(<", dist, ">, 1:2) of zero-length object"))
+        expect_identical(fit_mle(d, 1:2), numeric(),
+            info = paste0("expected numeric() from fit_mle(<", dist, ">, 1:2) of zero-length object"))
+    }
+})
+
+


### PR DESCRIPTION
See also #125 

@zeileis : As discussed yesterday I went trough all existing constructor functions for distribution objects and added defaults for the parameters (`numeric()`), so that all constructors can be called with no arguments. In addition, allowing constructor functions with defaults to also be called with `numeric()` to create zero-length distribution objects. E.g., `Normal(numeric(), numeric())` results in an object of length 0.

In addition updated all S3 methods so that they can handle "zero-length" distribution objects and all return the same objects (typically empty vectors `numeric()` or `logical()`).

Added automated tests to check this works for all existing distributions.

TODO(R): Forgot `suff_stat` and `fit_mle` (will check that in a second).

# For the records

## Existing defaults                                                            
                                                                                
* Bernoulli: `p = 0.5`                                                          
* Beta: `alpha = 1`, `beta = 1`                                                 
* Cauchy: `location = 0`, `scale = 1`                                           
* Exponential: `rate = 1`                                                       
* Frechet: `location = 0`, `scale = 1`, `shape = 1`                             
* GEV: `mu = 0`, `sigma = 1`, `xi = 0`                                          
* GP: `mu = 0`, `sigma = 1`, `xi = 0`                                           
* Geometric: `p = 0.5`                                                          
* Gumbel: `mu = 0`, `sigma = 1`                                                 
* LogNormal: `log_mu = 0`, `log_sigma = 1`                                      
* Logistic: `location = 0`, `scale = 1`                                         
* Normal: `mu = 0`, `sigma = 1`                                                 
* RevWeibull: `location = 0`, `scale = 1`, `shape = 1`                          
* Uniform: `a = 0`, `b = 1`                                                     
                                                                                
## New `numeric()` defaults                                                     
                                                                                
* Binomial                                                                      
* Categorical                                                                   
* ChiSquare                                                                     
* Empirical                                                                     
* Erlang                                                                        
* FisherF                                                                       
* Gamma                                                                         
* HurdleNegativeBinomial                                                        
* HurdlePoisson                                                                 
* HyperGeometric                                                                
* Multinomial                                                                   
* NegativeBinomial                                                              
* Poisson                                                                       
* PoissonBinomial                                                               
* StudentsT                                                                     
* Tukey                                                                         
* Weibull                                                                       
* ZTNegativeBinomial                                                            
* ZTPoisson